### PR TITLE
feat: 로그인 기능 구현 (#1)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_API_URL = http://localhost:8080/

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_API_URL = https://festa-go.site/

--- a/src/api/ApiResponse.ts
+++ b/src/api/ApiResponse.ts
@@ -1,0 +1,8 @@
+type ApiResponse<T> = {
+  errorCode: string | null,
+  message: string | null,
+  result: T | null
+}
+
+export default ApiResponse
+

--- a/src/api/FestagoError.ts
+++ b/src/api/FestagoError.ts
@@ -1,0 +1,16 @@
+class FestagoError implements Error {
+  name: string = '';
+  errorCode: string;
+  message: string;
+  status: number;
+  result: any;
+
+  constructor(errorCode: string, message: string, status: number, result: any) {
+    this.errorCode = errorCode;
+    this.message = message;
+    this.status = status;
+    this.result = result;
+  }
+}
+
+export default FestagoError;

--- a/src/api/auth/AuthService.ts
+++ b/src/api/auth/AuthService.ts
@@ -1,0 +1,23 @@
+import ApiService from '@/api';
+import { AuthType } from '@/type/AuthType.ts';
+
+export type LoginResponse = {
+  accessToken: string,
+  username: string,
+  authType: AuthType
+}
+
+const AuthService = {
+  async login(username: string, password: string) {
+    return ApiService.post<LoginResponse>('/admin/api/login', {
+      username,
+      password,
+    });
+  },
+  async logout() {
+    ApiService.changeAccessToken('');
+    return ApiService.get<null>('/admin/api/logout');
+  },
+};
+
+export default AuthService;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,42 @@
+import axios, { AxiosResponse } from 'axios';
+import FestagoError from '@/api/FestagoError.ts';
+
+const axiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_API_URL,
+  withCredentials: true,
+});
+
+axiosInstance.interceptors.response.use(value => value, error => {
+  const response = error.response;
+  if (response) {
+    return Promise.reject(new FestagoError(
+      response.data.errorCode,
+      response.data.message,
+      response.status,
+      response.data.result,
+    ));
+  }
+  return Promise.reject(new FestagoError(
+    '',
+    '서버에 연결할 수 없거나, 인터넷에 연결되어 있지 않습니다!',
+    0,
+    null,
+  ));
+});
+
+// TODO Promise<AxiosResponse<ApiResponse<T>>>와 같이 변경하려면 백엔드 API 명세가 변경되어야 함
+const ApiService = {
+  async get<T>(uri: string): Promise<AxiosResponse<T>> {
+    return await axiosInstance.get(uri);
+  },
+
+  async post<T>(uri: string, data: any): Promise<AxiosResponse<T>> {
+    return await axiosInstance.post(uri, data);
+  },
+
+  changeAccessToken(accessToken: string) {
+    axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+  },
+};
+
+export default ApiService;

--- a/src/components/navigation/AuthButton.vue
+++ b/src/components/navigation/AuthButton.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { useAuthStore } from '@/stores/useAuthStore.ts';
 import { router } from '@/router';
+import AuthService from '@/api/auth/AuthService.ts';
 
 const authStore = useAuthStore();
 
-function logout() {
+async function logout() {
+  await AuthService.logout();
   authStore.logout();
-  router.push('/login');
+  await router.push('/login');
 }
 </script>
 

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,8 +1,10 @@
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import { AuthType } from '@/type/AuthType.ts';
+import ApiService from '@/api';
 
 export const useAuthStore = defineStore('auth', () => {
+  const accessToken = ref('');
   const username = ref('');
   const authType = ref<AuthType>(AuthType.UNASSIGNED);
 
@@ -14,17 +16,24 @@ export const useAuthStore = defineStore('auth', () => {
     return authType.value !== AuthType.UNASSIGNED;
   });
 
-  function login(usernameInput: string, authTypeInput: AuthType) {
-    username.value = usernameInput;
-    authType.value = authTypeInput;
+  function login(dto: {
+    accessToken: string,
+    username: string,
+    authType: AuthType
+  }) {
+    accessToken.value = dto.accessToken;
+    username.value = dto.username;
+    authType.value = dto.authType;
   }
 
   function logout() {
+    accessToken.value = '';
     username.value = '';
     authType.value = AuthType.UNASSIGNED;
   }
 
   return {
+    accessToken,
     username,
     authType,
     isAdmin,
@@ -34,6 +43,10 @@ export const useAuthStore = defineStore('auth', () => {
   };
 }, {
   persist: {
-    storage: sessionStorage,
+    storage: localStorage,
+    afterRestore(_context) {
+      const authStore = useAuthStore();
+      ApiService.changeAccessToken(authStore.accessToken);
+    },
   },
 });

--- a/src/type/AuthType.ts
+++ b/src/type/AuthType.ts
@@ -1,7 +1,7 @@
 export const AuthType = {
-  ROOT: 'root',
-  ADMIN: 'admin',
-  SCHOOL: 'school',
-  UNASSIGNED: 'unassigned',
+  ROOT: 'ROOT',
+  ADMIN: 'ADMIN',
+  SCHOOL: 'SCHOOL',
+  UNASSIGNED: 'UNASSIGNED',
 } as const;
 export type AuthType = typeof AuthType[keyof typeof AuthType]

--- a/src/views/auth/LoginView.vue
+++ b/src/views/auth/LoginView.vue
@@ -2,22 +2,44 @@
 import { useAuthStore } from '@/stores/useAuthStore.ts';
 import { ref } from 'vue';
 import { router } from '@/router';
-import { AuthType } from '@/type/AuthType.ts';
+import AuthService from '@/api/auth/AuthService.ts';
+import ApiService from '@/api';
+import FestagoError from '@/api/FestagoError.ts';
 
 const authStore = useAuthStore();
 const visible = ref(false);
+const loginInput = ref({
+  username: '',
+  password: '',
+});
+const errorMessage = ref('');
+const loading = ref(false);
+const form = ref(false);
+const rules = ref({
+  required: (value: any) => !!value,
+});
 
-// TODO 로그인 구현할 것
-function login() {
-  authStore.login('glen', AuthType.ROOT);
-  router.push('/');
+async function onSubmit() {
+  form.value = false;
+  loading.value = true;
+  setTimeout(() => (form.value = true), 1000);
+  try {
+    const response = await AuthService.login(loginInput.value.username, loginInput.value.password);
+    ApiService.changeAccessToken(response.data.accessToken);
+    authStore.login(response.data);
+    await router.push('/');
+  } catch (e) {
+    if (e instanceof FestagoError) {
+      loading.value = false;
+      errorMessage.value = e.message;
+    }
+  }
 }
-
 </script>
 
 <template>
   <v-card
-    class="mx-auto my-8 pa-12 pb-8"
+    class="mx-auto my-8 pa-15 pb-8"
     max-width="800"
     elevation="4"
   >
@@ -26,38 +48,58 @@ function login() {
         로그인
       </p>
     </v-card-title>
-
-    <div class="text-subtitle-1 text-medium-emphasis">
-      계정
-    </div>
-    <v-text-field
-      density="compact"
-      placeholder="계정을 입력해주세요."
-      prepend-inner-icon="mdi-account-outline"
-      variant="outlined"
-    />
-
-    <div class="text-subtitle-1 text-medium-emphasis d-flex align-center justify-space-between">
-      비밀번호
-    </div>
-    <v-text-field
-      :append-inner-icon="visible ? 'mdi-eye-off' : 'mdi-eye'"
-      :type="visible ? 'text' : 'password'"
-      density="compact"
-      placeholder="비밀번호를 입력해주세요."
-      prepend-inner-icon="mdi-lock-outline"
-      variant="outlined"
-      @click:append-inner="visible = !visible"
-    />
-
-    <v-btn
-      :block="true"
-      class="mb-8"
-      color="blue"
-      size="large"
-      @click="login"
+    <v-form
+      v-model="form"
+      @submit.prevent="onSubmit"
     >
-      로그인
-    </v-btn>
+      <p class="text-subtitle-1 text-medium-emphasis">
+        계정
+      </p>
+      <v-text-field
+        ref="qqc"
+        density="compact"
+        placeholder="ID를 입력해주세요."
+        prepend-inner-icon="mdi-account-outline"
+        variant="outlined"
+        maxlength="50"
+        v-model="loginInput.username"
+        :rules="[rules.required]"
+        :hide-details="true"
+      />
+      <span v-if="errorMessage" class="text-subtitle-2 text-red-darken-3">
+        {{ errorMessage }}
+      </span>
+      <p class="text-subtitle-1 text-medium-emphasis mt-1">
+        비밀번호
+      </p>
+      <v-text-field
+        :append-inner-icon="visible ? 'mdi-eye-off' : 'mdi-eye'"
+        :type="visible ? 'text' : 'password'"
+        density="compact"
+        placeholder="비밀번호를 입력해주세요."
+        prepend-inner-icon="mdi-lock-outline"
+        variant="outlined"
+        maxlength="50"
+        v-model="loginInput.password"
+        :rules="[rules.required]"
+        @click:append-inner="visible = !visible"
+        :hide-details="true"
+      />
+      <span v-if="errorMessage" class="text-subtitle-2 text-red-darken-3">
+        {{ errorMessage }}
+      </span>
+
+      <v-btn
+        :disabled="!form"
+        :loading="loading"
+        :block="true"
+        class="my-4"
+        color="blue"
+        size="large"
+        type="submit"
+      >
+        로그인
+      </v-btn>
+    </v-form>
   </v-card>
 </template>

--- a/src/views/auth/LoginView.vue
+++ b/src/views/auth/LoginView.vue
@@ -39,8 +39,9 @@ async function onSubmit() {
 
 <template>
   <v-card
-    class="mx-auto my-8 pa-15 pb-8"
+    class="mx-auto pa-3 pa-md-15 py-8 mt-16 w-75"
     max-width="800"
+    min-width="350"
     elevation="4"
   >
     <v-card-title>
@@ -88,7 +89,6 @@ async function onSubmit() {
       <span v-if="errorMessage" class="text-subtitle-2 text-red-darken-3">
         {{ errorMessage }}
       </span>
-
       <v-btn
         :disabled="!form"
         :loading="loading"

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
+// https://ko.vitejs.dev/guide/env-and-mode.html
 /// <reference types="vite/client" />
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## DONE
- [x] JWT 토큰 LocalStorage 저장  
- [x] Axios Environment에 따라 baseUrl 다르게 설정
- [x] 프론트 로그아웃 기능 구현 (쿠키 무효화용)

## TODO 
- 백엔드 API 명세 message, errorCode, result와 같이 감싸서 Response 보내야함
- 백엔드, 프론트엔드 리프레쉬 토큰 구현 