### PR TITLE
feat: 내비게이션 바 모바일 화면에 맞게 크기 조절

### DIFF
--- a/src/components/navigation/AuthButton.vue
+++ b/src/components/navigation/AuthButton.vue
@@ -13,10 +13,20 @@ async function logout() {
 </script>
 
 <template>
-  <v-btn prepend-icon="mdi-login" v-if="!authStore.isLogin" @click="$router.push('/login')">
+  <v-btn
+    v-if="!authStore.isLogin"
+    class="text-button"
+    prepend-icon="mdi-login"
+    @click="$router.push('/login')"
+  >
     로그인
   </v-btn>
-  <v-btn prepend-icon="mdi-logout" v-else @click="logout">
+  <v-btn
+    v-else
+    class="text-button"
+    prepend-icon="mdi-logout"
+    @click="logout"
+  >
     로그아웃
   </v-btn>
 </template>

--- a/src/components/navigation/Navigation.vue
+++ b/src/components/navigation/Navigation.vue
@@ -10,7 +10,11 @@ const drawerStore = useDrawerStore();
   <Drawer />
   <v-app-bar>
     <v-app-bar-nav-icon @click="drawerStore.toggle" />
-    <v-app-bar-title>페스타고 관리자 페이지</v-app-bar-title>
+    <v-app-bar-title>
+      <span class="text-body-1 text-md-h6">
+        페스타고 관리자 페이지
+      </span>
+    </v-app-bar-title>
     <AuthButton />
   </v-app-bar>
 </template>


### PR DESCRIPTION
## DONE
- 내비게이션 바 타이틀 모바일 화면일 때 폰트 사이즈 작게 변경
- 로그인, 로그아웃 버튼 사이즈 작게 변경

## TODO
- `AuthService.logout()` 메서드의 `ApiService.changeAccessToken('')` 메서드 호출을 `AuthButton` 컴포넌트 위치로 옮겨야 할 것 같음 혹은 백엔드에서 `/admin/api/logout`을 열어줘야 할 듯