### PR TITLE
feat: 학교 수정/삭제 페이지 추가 (#8)

### DIFF
--- a/src/api/admin/AdminSchoolService.ts
+++ b/src/api/admin/AdminSchoolService.ts
@@ -18,12 +18,14 @@ import { AxiosResponse } from 'axios';
  *   ]
  * }
  */
-export type AdminSchoolResponse = {
-  schools: {
-    id: number,
-    domain: string,
-    name: string,
-  }[]
+export type SchoolResponses = {
+  schools: SchoolResponse[]
+}
+
+export type SchoolResponse = {
+  id: number,
+  domain: string,
+  name: string
 }
 
 export type SchoolCreateRequest = {
@@ -31,14 +33,16 @@ export type SchoolCreateRequest = {
   domain: string
 }
 
-export type SchoolCreateResponse = {
-  id: number,
-  domain: string,
+export type SchoolUpdateRequest = {
   name: string,
+  domain: string
 }
 
 const AdminSchoolService = {
-  fetchSchools(paging: PagingRequest, search: SearchRequest): Promise<AxiosResponse<AdminSchoolResponse>> {
+  fetchSchool(schoolId: number): Promise<AxiosResponse<SchoolResponse>> {
+    return ApiService.get(`/schools/${schoolId}`);
+  },
+  fetchSchools(paging: PagingRequest, search: SearchRequest): Promise<AxiosResponse<SchoolResponses>> {
     return ApiService.get('/schools', {
       page: paging.page,
       size: paging.itemsPerPage,
@@ -48,8 +52,14 @@ const AdminSchoolService = {
       filterKeyword: search.filterKeyword,
     });
   },
-  createSchool(request: SchoolCreateRequest): Promise<AxiosResponse<SchoolCreateRequest>> {
+  createSchool(request: SchoolCreateRequest): Promise<AxiosResponse<SchoolResponse>> {
     return ApiService.post('/admin/api/schools', request);
+  },
+  updateSchool(schoolId: number, request: SchoolUpdateRequest) {
+    return ApiService.patch(`/admin/api/schools/${schoolId}`, request);
+  },
+  deleteSchool(schoolId: number) {
+    return ApiService.delete(`/admin/api/schools/${schoolId}`);
   },
 };
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -34,6 +34,14 @@ const ApiService = {
     return axiosInstance.post(uri, data);
   },
 
+  patch<T>(uri: string, data: any = null): Promise<AxiosResponse<T>> {
+    return axiosInstance.patch(uri, data);
+  },
+
+  delete<T>(uri: string, data: any = null): Promise<AxiosResponse<T>> {
+    return axiosInstance.delete(uri, data);
+  },
+
   changeAccessToken(accessToken: string) {
     axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
   },

--- a/src/router/modules/admin/adminRoutes.ts
+++ b/src/router/modules/admin/adminRoutes.ts
@@ -3,6 +3,7 @@ import AdminMyPageView from '@/views/admin/AdminMyPageView.vue';
 import AdminSchoolManageListView from '@/views/admin/school/AdminSchoolManageListView.vue';
 import AdminFestivalManageView from '@/views/admin/AdminFestivalManageView.vue';
 import AdminSchoolManageCreateView from '@/views/admin/school/AdminSchoolManageCreateView.vue';
+import AdminSchoolManageEditView from '@/views/admin/school/AdminSchoolManageEditView.vue';
 
 const adminRoutes = [
   {
@@ -28,7 +29,12 @@ const adminRoutes = [
   {
     path: '/admin/school/create',
     name: 'adminSchoolManageCreateView',
-    component: AdminSchoolManageCreateView
-  }
+    component: AdminSchoolManageCreateView,
+  },
+  {
+    path: '/admin/school/edit/:id',
+    name: 'adminSchoolManageEdit',
+    component: AdminSchoolManageEditView,
+  },
 ];
 export default adminRoutes;

--- a/src/views/admin/school/AdminSchoolManageEditView.vue
+++ b/src/views/admin/school/AdminSchoolManageEditView.vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { useField, useForm } from 'vee-validate';
+import AdminSchoolService, { SchoolUpdateRequest } from '@/api/admin/AdminSchoolService.ts';
+import { useRoute } from 'vue-router';
+import { useSnackbarStore } from '@/stores/useSnackbarStore.ts';
+import FestagoError from '@/api/FestagoError.ts';
+import { router } from '@/router';
+
+const route = useRoute();
+const snackbarStore = useSnackbarStore();
+
+onMounted(() => {
+  AdminSchoolService.fetchSchool(parseInt(route.params.id as string)).then(response => {
+    schoolId.value = response.data.id;
+    nameField.resetField({
+      value: response.data.name,
+    });
+    domainField.resetField({
+      value: response.data.domain,
+    });
+  }).catch(e => {
+    if (e instanceof FestagoError) {
+      router.push('/admin/school');
+      snackbarStore.showError('해당 학교를 찾을 수 없습니다.');
+    } else throw e;
+  });
+});
+
+const { handleSubmit, isFieldDirty } = useForm<SchoolUpdateRequest>({
+  validationSchema: {
+    name(value: string) {
+      if (!value) return '대학교 이름은 필수입니다.';
+      return true;
+    },
+    domain(value: string) {
+      if (!value) return '도메인은 필수입니다.';
+      return true;
+    },
+  },
+});
+
+const onUpdateSubmit = handleSubmit(request => {
+  loading.value = true;
+  setTimeout(() => (loading.value = false), 1000);
+  if (!isFieldDirty('name') && !isFieldDirty('domain')) {
+    snackbarStore.showError('아무것도 수정되지 않았습니다.');
+    return;
+  }
+  AdminSchoolService.updateSchool(schoolId.value!, request).then(() => {
+    loading.value = false;
+    snackbarStore.showSuccess('학교가 수정되었습니다.');
+    nameField.resetField({
+      value: nameField.value.value,
+    });
+    domainField.resetField({
+      value: domainField.value.value,
+    });
+  }).catch(e => {
+    if (e instanceof FestagoError) {
+      snackbarStore.showError(e.message);
+    } else throw e;
+  });
+});
+
+function deleteSchool() {
+  AdminSchoolService.deleteSchool(schoolId.value!).then(() => {
+    snackbarStore.showSuccess('학교가 삭제되었습니다.');
+    router.push('/admin/school');
+  }).catch(e => {
+    if (e instanceof FestagoError) {
+      snackbarStore.showError(e.message);
+    } else throw e;
+  });
+}
+
+const schoolId = ref<number>();
+const nameField = useField<string>('name');
+const domainField = useField<string>('domain');
+const invalidForm = ref(false);
+const loading = ref(false);
+const showDialog = ref(false);
+</script>
+
+<template>
+  <v-dialog
+    v-model="showDialog"
+    max-width="500"
+  >
+    <v-card class="pa-5">
+      <v-card-title class="text-h5 text-center">
+        정말로 삭제할까요?
+      </v-card-title>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn
+          text="취소"
+          color="blue-darken-1"
+          variant="text"
+          @click="showDialog = false"
+        />
+        <v-btn
+          text="삭제"
+          color="red-darken-1"
+          variant="text"
+          @click="deleteSchool"
+        />
+        <v-spacer />
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+  <v-card
+    class="mx-auto pa-3 pa-md-15 py-8 mt-16 w-75"
+    max-width="800"
+    min-width="350"
+    elevation="4"
+  >
+    <v-card-title class="mb-3 text-h4 text-center">
+      학교 수정/삭제
+    </v-card-title>
+    <v-form
+      v-model="invalidForm"
+      @submit.prevent="onUpdateSubmit"
+    >
+      <v-text-field
+        class="mb-3"
+        variant="outlined"
+        label="ID"
+        :model-value="schoolId"
+        :readonly="true"
+      />
+      <v-text-field
+        class="mb-3"
+        v-model="nameField.value.value"
+        :error-messages="nameField.errorMessage.value"
+        placeholder="XX대학교"
+        variant="outlined"
+        label="대학교 이름"
+      />
+      <v-text-field
+        class="mb-3"
+        v-model="domainField.value.value"
+        :error-messages="domainField.errorMessage.value"
+        placeholder="school.ac.kr"
+        variant="outlined"
+        label="학교 도메인"
+      />
+      <v-btn
+        :disabled="!invalidForm"
+        :loading="loading"
+        class="text-h6"
+        type="submit"
+        text="수정"
+        color="blue"
+        :block="true"
+      />
+      <v-btn
+        :disabled="loading"
+        class="text-h6 mt-4"
+        text="삭제"
+        color="red"
+        :block="true"
+        @click="showDialog = true"
+      />
+      <v-btn
+        :disabled="loading"
+        class="text-h6 mt-4"
+        text="취소"
+        color="grey"
+        :block="true"
+        @click="$router.go(-1)"
+      />
+    </v-form>
+  </v-card>
+</template>

--- a/src/views/admin/school/AdminSchoolManageListView.vue
+++ b/src/views/admin/school/AdminSchoolManageListView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Ref, ref } from 'vue';
-import AdminSchoolService, { AdminSchoolResponse } from '@/api/admin/AdminSchoolService.ts';
+import AdminSchoolService, { SchoolResponses } from '@/api/admin/AdminSchoolService.ts';
 import { PagingRequest } from '@/api/PagingRequest.ts';
 import { SearchRequest } from '@/api/SearchRequest.ts';
 
@@ -8,6 +8,7 @@ const tableHeaders = [
   { title: 'ID', key: 'id' },
   { title: '이름', key: 'name' },
   { title: '도메인', key: 'domain' },
+  { title: '수정/삭제', key: 'actions', sortable: false },
 ];
 const searchFilters = [
   { title: 'ID', value: 'id' },
@@ -15,15 +16,15 @@ const searchFilters = [
   { title: '도메인', value: 'domain' },
 ];
 const itemsPerPageOption = [
-  { value: 10, title:'10' },
-  { value: 25, title:'25' },
-  { value: 50, title:'50' },
-]
+  { value: 10, title: '10' },
+  { value: 25, title: '25' },
+  { value: 50, title: '50' },
+];
 const loading = ref(false);
 const itemsPerPage = ref(10);
 const totalItems = ref(0);
 const searchRequest: Ref<SearchRequest> = ref({ searchKeyword: null, filterKeyword: null });
-const items: Ref<AdminSchoolResponse> = ref({ schools: [] });
+const items: Ref<SchoolResponses> = ref({ schools: [] });
 
 // TODO 백엔드에서 검색 필터링을 구현해야함
 function searchResult() {
@@ -89,6 +90,15 @@ function fetchItems(paging: PagingRequest) {
       :items-per-page-options="itemsPerPageOption"
       v-model:items-per-page="itemsPerPage"
       @update:options="fetchItems"
-    />
+    >
+      <template v-slot:item.actions="{item}">
+        <v-icon
+          class="mr-2"
+          icon="mdi-pencil"
+          color="grey-darken-3"
+          @click="$router.push(`/admin/school/edit/${item.id}`)"
+        />
+      </template>
+    </v-data-table-server>
   </v-card>
 </template>


### PR DESCRIPTION
## DONE

![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/a5292d5a-4f4d-4329-8d15-99e49bf5be6b)

![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/fc0e3240-aba7-47c3-81ca-e5277015f333)

![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/74a6f587-b9a4-4dda-ba50-fb70e5961a70)

- 수정할 때, 수정한 곳이 없다면 수정되지 않는다.
- 수정은 특수 목적이 강하므로, Validate 처리는 공백만 하였다. (강제로 변경하려는 의도) 

## TODO

- 라우터의 주소가 생각보다 많이 사용된다. ex) `router.go()`를 사용하면 앞으로 갈 수 있으므로, `router.push()` 사용할 때
  - 상수로 라우터의 주소를 관리하는게 좋아보인다.
  - API 주소 또한 상수로 관리하는게 좋아보인다.
    - API 주소에 key-value 형식으로 Request, Response 명세(타입) 또한 관리하면 좋을듯?
- 축제 CRUD 기능을 구현한다. 