### PR TITLE
refactor: API 상수로 관리하도록 리팩터링, ApiSpec 추가 

### DIFF
--- a/src/api/admin/AdminSchoolService.ts
+++ b/src/api/admin/AdminSchoolService.ts
@@ -2,6 +2,17 @@ import { PagingRequest } from '@/api/PagingRequest.ts';
 import { SearchRequest } from '@/api/SearchRequest.ts';
 import ApiService from '@/api';
 import { AxiosResponse } from 'axios';
+import UpdateSchoolApiSpec, {
+  UpdateSchoolRequest,
+  UpdateSchoolResponse,
+} from '@/api/spec/school/UpdateSchoolApiSpec.ts';
+import FetchSchoolsApiSpec, { FetchSchoolsResponse } from '@/api/spec/school/FetchSchoolsApiSpec.ts';
+import CreateSchoolApiSpec, {
+  CreateSchoolRequest,
+  CreateSchoolResponse,
+} from '@/api/spec/school/CreateSchoolApiSpec.ts';
+import DeleteSchoolApiSpec, { DeleteSchoolResponse } from '@/api/spec/school/DeleteSchoolApiSpec.ts';
+import FetchOneSchoolApiSpec, { FetchOneSchoolResponse } from '@/api/spec/school/FetchOneSchoolApiSpec.ts';
 
 /**
  * TODO 미래에 다음과 같은 형식이 되어야 함
@@ -18,32 +29,13 @@ import { AxiosResponse } from 'axios';
  *   ]
  * }
  */
-export type SchoolResponses = {
-  schools: SchoolResponse[]
-}
-
-export type SchoolResponse = {
-  id: number,
-  domain: string,
-  name: string
-}
-
-export type SchoolCreateRequest = {
-  name: string,
-  domain: string
-}
-
-export type SchoolUpdateRequest = {
-  name: string,
-  domain: string
-}
 
 const AdminSchoolService = {
-  fetchSchool(schoolId: number): Promise<AxiosResponse<SchoolResponse>> {
-    return ApiService.get(`/schools/${schoolId}`);
+  fetchOneSchool(schoolId: number): Promise<AxiosResponse<FetchOneSchoolResponse>> {
+    return ApiService.request(FetchOneSchoolApiSpec(schoolId));
   },
-  fetchSchools(paging: PagingRequest, search: SearchRequest): Promise<AxiosResponse<SchoolResponses>> {
-    return ApiService.get('/schools', {
+  fetchSchools(paging: PagingRequest, search: SearchRequest): Promise<AxiosResponse<FetchSchoolsResponse>> {
+    return ApiService.request(FetchSchoolsApiSpec, {
       page: paging.page,
       size: paging.itemsPerPage,
       sortBy: paging.sortBy[0]?.key,
@@ -52,14 +44,14 @@ const AdminSchoolService = {
       filterKeyword: search.filterKeyword,
     });
   },
-  createSchool(request: SchoolCreateRequest): Promise<AxiosResponse<SchoolResponse>> {
-    return ApiService.post('/admin/api/schools', request);
+  createSchool(request: CreateSchoolRequest): Promise<AxiosResponse<CreateSchoolResponse>> {
+    return ApiService.request(CreateSchoolApiSpec, request);
   },
-  updateSchool(schoolId: number, request: SchoolUpdateRequest) {
-    return ApiService.patch(`/admin/api/schools/${schoolId}`, request);
+  updateSchool(schoolId: number, request: UpdateSchoolRequest): Promise<AxiosResponse<UpdateSchoolResponse>> {
+    return ApiService.request(UpdateSchoolApiSpec(schoolId), request);
   },
-  deleteSchool(schoolId: number) {
-    return ApiService.delete(`/admin/api/schools/${schoolId}`);
+  deleteSchool(schoolId: number): Promise<AxiosResponse<DeleteSchoolResponse>> {
+    return ApiService.request(DeleteSchoolApiSpec(schoolId));
   },
 };
 

--- a/src/api/auth/AuthService.ts
+++ b/src/api/auth/AuthService.ts
@@ -1,14 +1,14 @@
 import ApiService from '@/api';
 import LoginApiSpec, { LoginRequest, LoginResponse } from '@/api/spec/auth/LoginApiSpec.ts';
-import LogoutApiSpec, { LogoutRequest, LogoutResponse } from '@/api/spec/auth/LogoutApiSpec.ts';
+import LogoutApiSpec, { LogoutResponse } from '@/api/spec/auth/LogoutApiSpec.ts';
 
 const AuthService = {
   login(request: LoginRequest) {
     return ApiService.request<LoginResponse>(LoginApiSpec, request);
   },
-  logout(request: LogoutRequest) {
+  logout() {
     ApiService.changeAccessToken('');
-    return ApiService.request<LogoutResponse>(LogoutApiSpec, request);
+    return ApiService.request<LogoutResponse>(LogoutApiSpec);
   },
 };
 

--- a/src/api/auth/AuthService.ts
+++ b/src/api/auth/AuthService.ts
@@ -1,24 +1,14 @@
 import ApiService from '@/api';
-import { AuthType } from '@/type/AuthType.ts';
-
-export type LoginRequest = {
-  username: string,
-  password: string
-}
-
-export type LoginResponse = {
-  accessToken: string,
-  username: string,
-  authType: AuthType
-}
+import LoginApiSpec, { LoginRequest, LoginResponse } from '@/api/spec/auth/LoginApiSpec.ts';
+import LogoutApiSpec, { LogoutRequest, LogoutResponse } from '@/api/spec/auth/LogoutApiSpec.ts';
 
 const AuthService = {
   login(request: LoginRequest) {
-    return ApiService.post<LoginResponse>('/admin/api/login', request);
+    return ApiService.request<LoginResponse>(LoginApiSpec, request);
   },
-  logout() {
+  logout(request: LogoutRequest) {
     ApiService.changeAccessToken('');
-    return ApiService.get<null>('/admin/api/logout');
+    return ApiService.request<LogoutResponse>(LogoutApiSpec, request);
   },
 };
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosResponse } from 'axios';
 import FestagoError from '@/api/FestagoError.ts';
+import ApiSpec from '@/api/spec/ApiSpec.ts';
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
@@ -24,22 +25,19 @@ axiosInstance.interceptors.response.use(value => value, error => {
   ));
 });
 
+const apiActions = {
+  'GET': <T>(url: string, queryParam: any = null): Promise<AxiosResponse<T>> => axiosInstance.get(url, { params: queryParam }),
+  'POST': <T>(url: string, data: any = null): Promise<AxiosResponse<T>> => axiosInstance.post(url, data),
+  'PATCH': <T>(url: string, data: any = null): Promise<AxiosResponse<T>> => axiosInstance.patch(url, data),
+  'DELETE': <T>(url: string, data: any = null): Promise<AxiosResponse<T>> => axiosInstance.delete(url, data),
+};
+
 // TODO Promise<AxiosResponse<ApiResponse<T>>>와 같이 변경하려면 백엔드 API 명세가 변경되어야 함
 const ApiService = {
-  get<T>(uri: string, queryParam: any = null): Promise<AxiosResponse<T>> {
-    return axiosInstance.get(uri, { params: queryParam });
-  },
-
-  post<T>(uri: string, data: any): Promise<AxiosResponse<T>> {
-    return axiosInstance.post(uri, data);
-  },
-
-  patch<T>(uri: string, data: any = null): Promise<AxiosResponse<T>> {
-    return axiosInstance.patch(uri, data);
-  },
-
-  delete<T>(uri: string, data: any = null): Promise<AxiosResponse<T>> {
-    return axiosInstance.delete(uri, data);
+  request<T>(spec: ApiSpec, data: any = null): Promise<AxiosResponse<T>> {
+    const { url, method } = spec;
+    const apiAction = apiActions[method];
+    return apiAction(url, data);
   },
 
   changeAccessToken(accessToken: string) {

--- a/src/api/spec/ApiSpec.ts
+++ b/src/api/spec/ApiSpec.ts
@@ -1,0 +1,6 @@
+interface ApiSpec {
+  url: string;
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+}
+
+export default ApiSpec;

--- a/src/api/spec/auth/LoginApiSpec.ts
+++ b/src/api/spec/auth/LoginApiSpec.ts
@@ -1,0 +1,20 @@
+import { AuthType } from '@/type/AuthType.ts';
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+
+export interface LoginRequest {
+  username: string,
+  password: string
+}
+
+export interface LoginResponse {
+  accessToken: string,
+  username: string,
+  authType: AuthType
+}
+
+const LoginApiSpec: ApiSpec = {
+  url: '/admin/api/login',
+  method: 'POST',
+};
+
+export default LoginApiSpec;

--- a/src/api/spec/auth/LogoutApiSpec.ts
+++ b/src/api/spec/auth/LogoutApiSpec.ts
@@ -1,0 +1,16 @@
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+
+export interface LogoutRequest {
+  // empty
+}
+
+export interface LogoutResponse {
+  // empty
+}
+
+const LogoutApiSpec: ApiSpec = {
+  url: '/admin/api/logout',
+  method: 'GET',
+};
+
+export default LogoutApiSpec;

--- a/src/api/spec/school/CreateSchoolApiSpec.ts
+++ b/src/api/spec/school/CreateSchoolApiSpec.ts
@@ -1,0 +1,19 @@
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+
+export type CreateSchoolRequest = {
+  name: string,
+  domain: string
+}
+
+export type CreateSchoolResponse = {
+  id: number,
+  domain: string,
+  name: string
+}
+
+const CreateSchoolApiSpec: ApiSpec = {
+  url: '/admin/api/schools',
+  method: 'POST',
+};
+
+export default CreateSchoolApiSpec;

--- a/src/api/spec/school/DeleteSchoolApiSpec.ts
+++ b/src/api/spec/school/DeleteSchoolApiSpec.ts
@@ -1,0 +1,16 @@
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+
+export type DeleteSchoolRequest = {
+  // empty
+}
+
+export type DeleteSchoolResponse = {
+  // empty
+}
+
+const DeleteSchoolApiSpec = (schoolId: number): ApiSpec => ({
+  url: `/admin/api/schools/${schoolId}`,
+  method: 'DELETE',
+});
+
+export default DeleteSchoolApiSpec;

--- a/src/api/spec/school/FetchOneSchoolApiSpec.ts
+++ b/src/api/spec/school/FetchOneSchoolApiSpec.ts
@@ -1,0 +1,18 @@
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+
+export type FetchOneSchoolRequest = {
+  // empty
+}
+
+export type FetchOneSchoolResponse = {
+  id: number,
+  domain: string,
+  name: string
+}
+
+const FetchOneSchoolApiSpec = (schoolId: number): ApiSpec => ({
+  url: `/schools/${schoolId}`,
+  method: 'GET',
+});
+
+export default FetchOneSchoolApiSpec;

--- a/src/api/spec/school/FetchSchoolsApiSpec.ts
+++ b/src/api/spec/school/FetchSchoolsApiSpec.ts
@@ -1,0 +1,20 @@
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+
+export type FetchSchoolsRequest = {
+  // empty
+}
+
+export type FetchSchoolsResponse = {
+  schools: {
+    id: number,
+    domain: string,
+    name: string
+  }[]
+}
+
+const FetchSchoolsApiSpec: ApiSpec = {
+  url: '/schools',
+  method: 'GET',
+};
+
+export default FetchSchoolsApiSpec;

--- a/src/api/spec/school/UpdateSchoolApiSpec.ts
+++ b/src/api/spec/school/UpdateSchoolApiSpec.ts
@@ -1,0 +1,17 @@
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+
+export type UpdateSchoolRequest = {
+  name: string,
+  domain: string
+}
+
+export type UpdateSchoolResponse = {
+  // empty
+}
+
+const UpdateSchoolApiSpec = (schoolId: number): ApiSpec => ({
+  url: `/admin/api/schools/${schoolId}`,
+  method: 'PATCH',
+});
+
+export default UpdateSchoolApiSpec;

--- a/src/views/admin/school/AdminSchoolManageCreateView.vue
+++ b/src/views/admin/school/AdminSchoolManageCreateView.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { useField, useForm } from 'vee-validate';
-import AdminSchoolService, { SchoolCreateRequest } from '@/api/admin/AdminSchoolService.ts';
+import AdminSchoolService from '@/api/admin/AdminSchoolService.ts';
 import { ref } from 'vue';
 import { useSnackbarStore } from '@/stores/useSnackbarStore.ts';
 import FestagoError from '@/api/FestagoError.ts';
+import { CreateSchoolRequest } from '@/api/spec/school/CreateSchoolApiSpec.ts';
 
 const snackbarStore = useSnackbarStore();
-const { handleSubmit, handleReset } = useForm<SchoolCreateRequest>({
+const { handleSubmit, handleReset } = useForm<CreateSchoolRequest>({
   validationSchema: {
     name(value: string) {
       if (!value) return '대학교 이름은 필수입니다.';

--- a/src/views/admin/school/AdminSchoolManageEditView.vue
+++ b/src/views/admin/school/AdminSchoolManageEditView.vue
@@ -1,18 +1,19 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
 import { useField, useForm } from 'vee-validate';
-import AdminSchoolService, { SchoolUpdateRequest } from '@/api/admin/AdminSchoolService.ts';
+import AdminSchoolService from '@/api/admin/AdminSchoolService.ts';
 import { useRoute } from 'vue-router';
 import { useSnackbarStore } from '@/stores/useSnackbarStore.ts';
 import FestagoError from '@/api/FestagoError.ts';
 import { router } from '@/router';
 import RouterPath from '@/router/RouterPath.ts';
+import { UpdateSchoolRequest } from '@/api/spec/school/UpdateSchoolApiSpec.ts';
 
 const route = useRoute();
 const snackbarStore = useSnackbarStore();
 
 onMounted(() => {
-  AdminSchoolService.fetchSchool(parseInt(route.params.id as string)).then(response => {
+  AdminSchoolService.fetchOneSchool(parseInt(route.params.id as string)).then(response => {
     schoolId.value = response.data.id;
     nameField.resetField({
       value: response.data.name,
@@ -28,7 +29,7 @@ onMounted(() => {
   });
 });
 
-const { handleSubmit, isFieldDirty } = useForm<SchoolUpdateRequest>({
+const { handleSubmit, isFieldDirty } = useForm<UpdateSchoolRequest>({
   validationSchema: {
     name(value: string) {
       if (!value) return '대학교 이름은 필수입니다.';

--- a/src/views/admin/school/AdminSchoolManageListView.vue
+++ b/src/views/admin/school/AdminSchoolManageListView.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { Ref, ref } from 'vue';
-import AdminSchoolService, { SchoolResponses } from '@/api/admin/AdminSchoolService.ts';
+import AdminSchoolService from '@/api/admin/AdminSchoolService.ts';
 import { PagingRequest } from '@/api/PagingRequest.ts';
 import { SearchRequest } from '@/api/SearchRequest.ts';
 import RouterPath from '@/router/RouterPath.ts';
+import { FetchSchoolsResponse } from '@/api/spec/school/FetchSchoolsApiSpec.ts';
 
 const tableHeaders = [
   { title: 'ID', key: 'id' },
@@ -25,7 +26,7 @@ const loading = ref(false);
 const itemsPerPage = ref(10);
 const totalItems = ref(0);
 const searchRequest: Ref<SearchRequest> = ref({ searchKeyword: null, filterKeyword: null });
-const items: Ref<SchoolResponses> = ref({ schools: [] });
+const items: Ref<FetchSchoolsResponse> = ref({ schools: [] });
 
 // TODO 백엔드에서 검색 필터링을 구현해야함
 function searchResult() {

--- a/src/views/auth/LoginView.vue
+++ b/src/views/auth/LoginView.vue
@@ -2,12 +2,13 @@
 import { useAuthStore } from '@/stores/useAuthStore.ts';
 import { ref } from 'vue';
 import { router } from '@/router';
-import AuthService, { LoginRequest } from '@/api/auth/AuthService.ts';
+import AuthService from '@/api/auth/AuthService.ts';
 import ApiService from '@/api';
 import FestagoError from '@/api/FestagoError.ts';
 import { useSnackbarStore } from '@/stores/useSnackbarStore.ts';
 import { useField, useForm } from 'vee-validate';
 import RouterPath from '@/router/RouterPath.ts';
+import { LoginRequest } from '@/api/spec/auth/LoginApiSpec.ts';
 
 const authStore = useAuthStore();
 const snackbarStore = useSnackbarStore();


### PR DESCRIPTION
## DONE

API 요청 시 `ApiSpec` 타입을 받도록 하여, 휴먼 에러 방지

```ts
interface ApiSpec {
  url: string;
  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
}
```
```ts
const apiActions = {
  'GET': <T>(url: string, queryParam: any = null): Promise<AxiosResponse<T>> => axiosInstance.get(url, { params: queryParam }),
  'POST': <T>(url: string, data: any = null): Promise<AxiosResponse<T>> => axiosInstance.post(url, data),
  'PATCH': <T>(url: string, data: any = null): Promise<AxiosResponse<T>> => axiosInstance.patch(url, data),
  'DELETE': <T>(url: string, data: any = null): Promise<AxiosResponse<T>> => axiosInstance.delete(url, data),
};

const ApiService = {
  request<T>(spec: ApiSpec, data: any = null): Promise<AxiosResponse<T>> {
    const { url, method } = spec;
    const apiAction = apiActions[method];
    return apiAction(url, data);
  },
  ...
}
```
PathVariable이 필요하지 않은 경우 다음과 같이 `ApiSpec`을 구현해서 사용
```ts
const LoginApiSpec: ApiSpec = {
  url: '/admin/api/login',
  method: 'POST',
};
```

PathVariable이 필요할 경우, 반환 타입이 `ApiSpec`인 함수로 정의하여 사용
```ts
const UpdateSchoolApiSpec = (schoolId: number): ApiSpec => ({
  url: `/admin/api/schools/${schoolId}`,
  method: 'PATCH',
});
```