### PR TITLE
fix: FestagoError name 필드 올바르게 정의 (#27)

### DIFF
--- a/src/api/FestagoError.ts
+++ b/src/api/FestagoError.ts
@@ -1,5 +1,5 @@
 class FestagoError implements Error {
-  name: string = '';
+  name: string = 'FestagoError';
   errorCode: string;
   message: string;
   status: number;


### PR DESCRIPTION
## DONE

### Before
```ts
class FestagoError implements Error {
  name: string = '';
  ...
}
```

### After
```ts
class FestagoError implements Error {
  name: string = 'FestagoError';
  ...
}
```