### PR TITLE
refactor: AdminSchoolManageListView의 검색폼과 데이터 테이블을 컴포넌트로 분리 (#33)

### DIFF
--- a/src/api/SearchRequest.ts
+++ b/src/api/SearchRequest.ts
@@ -1,4 +1,4 @@
 export interface SearchRequest {
+  searchFilter: string | null,
   searchKeyword: string | null,
-  filterKeyword: string | null,
 }

--- a/src/api/admin/AdminSchoolService.ts
+++ b/src/api/admin/AdminSchoolService.ts
@@ -23,8 +23,8 @@ const AdminSchoolService = {
       size: paging.itemsPerPage,
       sortBy: paging.sortBy[0]?.key,
       order: paging.sortBy[0]?.order,
+      filterKeyword: search.searchFilter,
       searchKeyword: search.searchKeyword,
-      filterKeyword: search.filterKeyword,
     });
   },
   createSchool(request: CreateSchoolRequest) {

--- a/src/components/datatable/DataTable.vue
+++ b/src/components/datatable/DataTable.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+
+import { PagingRequest } from '@/api/PagingRequest.ts';
+
+const model = defineModel({
+  default: false,
+});
+const props = defineProps<{
+  tableHeaders: {
+    title: string,
+    key: string,
+    sortable?: boolean,
+  }[],
+  itemsPerPageOptions: {
+    title: string,
+    value: number,
+  }[],
+  fetch: (request: PagingRequest) => {},
+  itemLength: number,
+  items: any[],
+  detailPageRouterName?: string
+}>();
+
+</script>
+
+<template>
+  <v-data-table-server
+    :headers="props.tableHeaders"
+    :loading="model"
+    :items-length="props.itemLength"
+    :items="props.items"
+    :items-per-page-options="props.itemsPerPageOptions"
+    @update:options="props.fetch"
+  >
+    <template v-slot:item.actions="{item}" v-if="!!(props.detailPageRouterName)">
+      <v-icon
+        class="mr-2"
+        icon="mdi-pencil"
+        color="grey-darken-3"
+        @click="$router.push({
+          name: props.detailPageRouterName,
+          params: { id: item.id }
+        })"
+      />
+    </template>
+  </v-data-table-server>
+</template>

--- a/src/components/datatable/DataTable.vue
+++ b/src/components/datatable/DataTable.vue
@@ -15,7 +15,7 @@ const props = defineProps<{
     title: string,
     value: number,
   }[],
-  fetch: (request: PagingRequest) => {},
+  fetch: (request: PagingRequest) => void,
   itemLength: number,
   items: any[],
   detailPageRouterName?: string

--- a/src/components/form/SearchForm.vue
+++ b/src/components/form/SearchForm.vue
@@ -4,7 +4,7 @@ import { SearchRequest } from '@/api/SearchRequest.ts';
 
 const props = defineProps<{
   searchFilters: { title: string, value: string }[]
-  search: (searchRequest: SearchRequest) => {}
+  search: (searchRequest: SearchRequest) => void
 }>();
 const searchRequest = ref<SearchRequest>({ searchFilter: null, searchKeyword: null });
 const loading = ref(false);

--- a/src/components/form/SearchForm.vue
+++ b/src/components/form/SearchForm.vue
@@ -3,10 +3,10 @@ import { ref } from 'vue';
 import { SearchRequest } from '@/api/SearchRequest.ts';
 
 const props = defineProps<{
-  filterKeywords: { title: string, value: string }[]
+  searchFilters: { title: string, value: string }[]
   search: (searchRequest: SearchRequest) => {}
 }>();
-const searchRequest = ref<SearchRequest>({ filterKeyword: '', searchKeyword: '' });
+const searchRequest = ref<SearchRequest>({ searchFilter: null, searchKeyword: null });
 const loading = ref(false);
 
 function searchFunction() {
@@ -24,10 +24,10 @@ function searchFunction() {
       <v-col :cols="3">
         <v-select
           class="pa-2 ma-2"
-          v-model="searchRequest.filterKeyword"
+          v-model="searchRequest.searchFilter"
           :clearable="true"
           label="필터"
-          :items="props.filterKeywords"
+          :items="props.searchFilters"
           variant="outlined"
           :hide-details="true"
         />
@@ -47,7 +47,7 @@ function searchFunction() {
       <v-col :cols="1">
         <v-btn
           :loading="loading"
-          :disabled="!(!!(searchRequest.searchKeyword && searchRequest.filterKeyword))"
+          :disabled="!(!!(searchRequest.searchKeyword && searchRequest.searchFilter))"
           class="py-7 text-h6"
           color="blue"
           type="submit"

--- a/src/components/form/SearchForm.vue
+++ b/src/components/form/SearchForm.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { SearchRequest } from '@/api/SearchRequest.ts';
+
+const props = defineProps<{
+  filterKeywords: { title: string, value: string }[]
+  search: (searchRequest: SearchRequest) => {}
+}>();
+const searchRequest = ref<SearchRequest>({ filterKeyword: '', searchKeyword: '' });
+const loading = ref(false);
+
+function searchFunction() {
+  loading.value = true;
+  setTimeout(() => loading.value = false, 500);
+  props.search(searchRequest.value);
+}
+</script>
+
+<template>
+  <v-form
+    @submit.prevent="searchFunction"
+  >
+    <v-row :no-gutters="true" align="center">
+      <v-col :cols="3">
+        <v-select
+          class="pa-2 ma-2"
+          v-model="searchRequest.filterKeyword"
+          :clearable="true"
+          label="필터"
+          :items="props.filterKeywords"
+          variant="outlined"
+          :hide-details="true"
+        />
+      </v-col>
+      <v-col :cols="8">
+        <v-text-field
+          class="pa-2 ma-2"
+          v-model="searchRequest.searchKeyword"
+          label="Search"
+          prepend-inner-icon="mdi-magnify"
+          :single-line="true"
+          variant="outlined"
+          :hide-details="true"
+          maxLength="50"
+        />
+      </v-col>
+      <v-col :cols="1">
+        <v-btn
+          :loading="loading"
+          :disabled="!(!!(searchRequest.searchKeyword && searchRequest.filterKeyword))"
+          class="py-7 text-h6"
+          color="blue"
+          type="submit"
+          variant="flat"
+          :block="true"
+          text="검색"
+        />
+      </v-col>
+    </v-row>
+  </v-form>
+</template>

--- a/src/views/admin/school/AdminSchoolManageListView.vue
+++ b/src/views/admin/school/AdminSchoolManageListView.vue
@@ -26,7 +26,7 @@ const itemsPerPageOption = [
 const loading = ref(false);
 const itemsPerPage = ref(10);
 const totalItems = ref(0);
-const searchRequest: Ref<SearchRequest> = ref({ searchKeyword: null, filterKeyword: null });
+const searchRequest: Ref<SearchRequest> = ref({ searchFilter: null, searchKeyword: null });
 const items: Ref<FetchSchoolsResponse> = ref({ schools: [] });
 
 // TODO 백엔드에서 검색 필터링을 구현해야함

--- a/src/views/admin/school/AdminSchoolManageListView.vue
+++ b/src/views/admin/school/AdminSchoolManageListView.vue
@@ -6,6 +6,7 @@ import { SearchRequest } from '@/api/SearchRequest.ts';
 import RouterPath from '@/router/RouterPath.ts';
 import { FetchSchoolsResponse } from '@/api/spec/school/FetchSchoolsApiSpec.ts';
 import SearchForm from '@/components/form/SearchForm.vue';
+import DataTable from '@/components/datatable/DataTable.vue';
 
 const tableHeaders = [
   { title: 'ID', key: 'id' },
@@ -18,33 +19,33 @@ const searchFilters = [
   { title: '이름', value: 'name' },
   { title: '도메인', value: 'domain' },
 ];
-const itemsPerPageOption = [
+const itemsPerPageOptions = [
+  { value: 1, title: '1' },
   { value: 10, title: '10' },
   { value: 25, title: '25' },
   { value: 50, title: '50' },
 ];
 const loading = ref(false);
 const itemsPerPage = ref(10);
-const totalItems = ref(0);
 const searchRequest: Ref<SearchRequest> = ref({ searchFilter: null, searchKeyword: null });
 const items: Ref<FetchSchoolsResponse> = ref({ schools: [] });
 
 // TODO 백엔드에서 검색 필터링을 구현해야함
 function search(origin: SearchRequest) {
   searchRequest.value = origin;
-  fetchItems({
+  fetch({
     page: 1,
     itemsPerPage: itemsPerPage.value,
     sortBy: [],
   });
 }
 
-function fetchItems(paging: PagingRequest) {
+function fetch(paging: PagingRequest) {
   loading.value = true;
+  setTimeout(() => (loading.value = false), 1000)
   AdminSchoolService.fetchSchools(paging, searchRequest.value).then(response => {
     const { schools } = response.data;
     items.value.schools = schools;
-    totalItems.value = schools.length;
     loading.value = false;
   });
 }
@@ -60,26 +61,13 @@ function fetchItems(paging: PagingRequest) {
       :search="search"
       :search-filters="searchFilters"
     />
-    <v-data-table-server
-      :headers="tableHeaders"
-      :items-length="totalItems"
+    <DataTable
+      :table-headers="tableHeaders"
+      :items-per-page-options="itemsPerPageOptions"
+      :fetch="fetch"
+      :item-length="items.schools.length"
       :items="items.schools"
-      :loading="loading"
-      :items-per-page-options="itemsPerPageOption"
-      v-model:items-per-page="itemsPerPage"
-      @update:options="fetchItems"
-    >
-      <template v-slot:item.actions="{item}">
-        <v-icon
-          class="mr-2"
-          icon="mdi-pencil"
-          color="grey-darken-3"
-          @click="$router.push({
-            name: RouterPath.Admin.AdminSchoolManageEditPage.name,
-            params: { id: item.id }
-          })"
-        />
-      </template>
-    </v-data-table-server>
+      :detail-page-router-name="RouterPath.Admin.AdminSchoolManageEditPage.name"
+    />
   </v-card>
 </template>

--- a/src/views/admin/school/AdminSchoolManageListView.vue
+++ b/src/views/admin/school/AdminSchoolManageListView.vue
@@ -5,6 +5,7 @@ import { PagingRequest } from '@/api/PagingRequest.ts';
 import { SearchRequest } from '@/api/SearchRequest.ts';
 import RouterPath from '@/router/RouterPath.ts';
 import { FetchSchoolsResponse } from '@/api/spec/school/FetchSchoolsApiSpec.ts';
+import SearchForm from '@/components/form/SearchForm.vue';
 
 const tableHeaders = [
   { title: 'ID', key: 'id' },
@@ -29,8 +30,13 @@ const searchRequest: Ref<SearchRequest> = ref({ searchKeyword: null, filterKeywo
 const items: Ref<FetchSchoolsResponse> = ref({ schools: [] });
 
 // TODO 백엔드에서 검색 필터링을 구현해야함
-function searchResult() {
-  console.log('구현 예정');
+function search(origin: SearchRequest) {
+  searchRequest.value = origin;
+  fetchItems({
+    page: 1,
+    itemsPerPage: itemsPerPage.value,
+    sortBy: [],
+  });
 }
 
 function fetchItems(paging: PagingRequest) {
@@ -50,41 +56,10 @@ function fetchItems(paging: PagingRequest) {
     :flat="true"
     title="학교 목록"
   >
-    <v-row :no-gutters="true" align="center">
-      <v-col :cols="3">
-        <v-select
-          v-model="searchRequest.filterKeyword"
-          class="pa-2 ma-2"
-          :clearable="true"
-          label="필터"
-          :items="searchFilters"
-          variant="outlined"
-          :hide-details="true"
-        />
-      </v-col>
-      <v-col :cols="8">
-        <v-text-field
-          class="pa-2 ma-2"
-          v-model="searchRequest.searchKeyword"
-          label="Search"
-          prepend-inner-icon="mdi-magnify"
-          :single-line="true"
-          variant="outlined"
-          :hide-details="true"
-          maxLength="50"
-        />
-      </v-col>
-      <v-col :cols="1">
-        <v-btn
-          class="py-7 text-h6"
-          color="blue"
-          variant="flat"
-          :block="true"
-          @click="searchResult"
-          text="검색"
-        />
-      </v-col>
-    </v-row>
+    <SearchForm
+      :search="search"
+      :search-filters="searchFilters"
+    />
     <v-data-table-server
       :headers="tableHeaders"
       :items-length="totalItems"


### PR DESCRIPTION
## DONE

다음과 같이 `SearchForm`과 `DataTable`을 분리했다.

```vue
<template>
  <v-card
    class="pa-10 ma-10 pt-0"
    :flat="true"
    title="학교 목록"
  >
    <SearchForm
      :search="search"
      :search-filters="searchFilters"
    />
    <DataTable
      :table-headers="tableHeaders"
      :items-per-page-options="itemsPerPageOptions"
      :fetch="fetch"
      :item-length="items.schools.length"
      :items="items.schools"
      :detail-page-router-name="RouterPath.Admin.AdminSchoolManageEditPage.name"
    />
  </v-card>
</template>
```

`SearchForm`에는 다음과 같은 함수를 구현해서 prop으로 전달해야한다.
(model을 사용할 수 있지만, 검색 버튼을 누르지 않아도 페이징 시, 검색 필터링이 적용되므로 버튼을 눌러야 검색폼의 필터링이 적용되게 하였다)
```ts
function search(origin: SearchRequest) {
  searchRequest.value = origin;
  fetch({
    page: 1,
    itemsPerPage: itemsPerPage.value,
    sortBy: [],
  });
}
```

`DataTable`에는 다음과 같은 함수를 구현해서 prop으로 전달해야한다.

```ts
function fetch(paging: PagingRequest) {
  loading.value = true;
  setTimeout(() => (loading.value = false), 1000)
  AdminSchoolService.fetchSchools(paging, searchRequest.value).then(response => {
    const { schools } = response.data;
    items.value.schools = schools;
    loading.value = false;
  });
}
```
