### PR TITLE
fix: DataTable 누락된 model 추가 (#35)

### DIFF
--- a/src/components/datatable/DataTable.vue
+++ b/src/components/datatable/DataTable.vue
@@ -3,7 +3,7 @@
 import { PagingRequest } from '@/api/PagingRequest.ts';
 
 const model = defineModel({
-  default: false,
+  required: true,
 });
 const props = defineProps<{
   tableHeaders: {

--- a/src/components/datatable/DataTable.vue
+++ b/src/components/datatable/DataTable.vue
@@ -2,9 +2,7 @@
 
 import { PagingRequest } from '@/api/PagingRequest.ts';
 
-const model = defineModel({
-  required: true,
-});
+const loading = defineModel<boolean>('loading', { required: true });
 const props = defineProps<{
   tableHeaders: {
     title: string,
@@ -26,7 +24,7 @@ const props = defineProps<{
 <template>
   <v-data-table-server
     :headers="props.tableHeaders"
-    :loading="model"
+    :loading="loading"
     :items-length="props.itemLength"
     :items="props.items"
     :items-per-page-options="props.itemsPerPageOptions"

--- a/src/views/admin/school/AdminSchoolManageListView.vue
+++ b/src/views/admin/school/AdminSchoolManageListView.vue
@@ -62,6 +62,7 @@ function fetch(paging: PagingRequest) {
       :search-filters="searchFilters"
     />
     <DataTable
+      v-model="loading"
       :table-headers="tableHeaders"
       :items-per-page-options="itemsPerPageOptions"
       :fetch="fetch"

--- a/src/views/admin/school/AdminSchoolManageListView.vue
+++ b/src/views/admin/school/AdminSchoolManageListView.vue
@@ -62,7 +62,7 @@ function fetch(paging: PagingRequest) {
       :search-filters="searchFilters"
     />
     <DataTable
-      v-model="loading"
+      :loading="loading"
       :table-headers="tableHeaders"
       :items-per-page-options="itemsPerPageOptions"
       :fetch="fetch"


### PR DESCRIPTION
## DONE

```vue
<DataTable
  :loading="loading" // <-- 추가
  :table-headers="tableHeaders"
  :items-per-page-options="itemsPerPageOptions"
  :fetch="fetch"
  :item-length="items.schools.length"
  :items="items.schools"
  :detail-page-router-name="RouterPath.Admin.AdminSchoolManageEditPage.name"
/>
```