### PR TITLE
feat: 아티스트 수정/삭제 페이지 추가 (#40)

### DIFF
--- a/src/api/admin/AdminArtistService.ts
+++ b/src/api/admin/AdminArtistService.ts
@@ -4,6 +4,12 @@ import CreateArtistApiSpec, {
   CreateArtistRequest,
   CreateArtistResponse,
 } from '@/api/spec/artist/CreateArtistApiSpec.ts';
+import FetchOneArtistApiSpec, { FetchOneArtistResponse } from '@/api/spec/artist/FetchOneArtistApiSpec.ts';
+import UpdateArtistApiSpec, {
+  UpdateArtistRequest,
+  UpdateArtistResponse,
+} from '@/api/spec/artist/UpdateArtistApiSpec.ts';
+import DeleteArtistApiSpec from '@/api/spec/artist/DeleteArtistApiSpec.ts';
 
 const AdminArtistService = {
   fetchArtists() {
@@ -11,6 +17,15 @@ const AdminArtistService = {
   },
   createArtist(request: CreateArtistRequest) {
     return ApiService.request<CreateArtistResponse>(CreateArtistApiSpec, request);
+  },
+  fetchOneArtist(artistId: number) {
+    return ApiService.request<FetchOneArtistResponse>(FetchOneArtistApiSpec(artistId));
+  },
+  updateArtist(artistId: number, request: UpdateArtistRequest) {
+    return ApiService.request<UpdateArtistResponse>(UpdateArtistApiSpec(artistId), request);
+  },
+  deleteArtist(artistId: number) {
+    return ApiService.request(DeleteArtistApiSpec(artistId));
   },
 };
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -30,6 +30,7 @@ const apiActions = {
   'POST': (url: string, data: any = null) => axiosInstance.post(url, data),
   'PATCH': (url: string, data: any = null) => axiosInstance.patch(url, data),
   'DELETE': (url: string, data: any = null) => axiosInstance.delete(url, data),
+  'PUT': (url: string, data: any = null) => axiosInstance.put(url, data),
 };
 
 const ApiService = {

--- a/src/api/spec/ApiSpec.ts
+++ b/src/api/spec/ApiSpec.ts
@@ -1,6 +1,6 @@
 interface ApiSpec {
   url: string;
-  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'PUT';
 }
 
 export default ApiSpec;

--- a/src/api/spec/artist/DeleteArtistApiSpec.ts
+++ b/src/api/spec/artist/DeleteArtistApiSpec.ts
@@ -1,0 +1,16 @@
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+
+export type DeleteArtistRequest = {
+  // empty
+}
+
+export type DeleteArtistResponse = {
+  // empty
+}
+
+const DeleteArtistApiSpec = (artistId: number): ApiSpec => ({
+  url: `/admin/api/v1/artists/${artistId}`,
+  method: 'DELETE',
+});
+
+export default DeleteArtistApiSpec;

--- a/src/api/spec/artist/FetchOneArtistApiSpec.ts
+++ b/src/api/spec/artist/FetchOneArtistApiSpec.ts
@@ -1,0 +1,18 @@
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+
+export type FetchOneArtistRequest = {
+  // empty
+}
+
+export type FetchOneArtistResponse = {
+  id: number,
+  name: string,
+  profileImage: string
+}
+
+const FetchOneArtistApiSpec = (artistId: number): ApiSpec => ({
+  url: `/admin/api/v1/artists/${artistId}`,
+  method: 'GET',
+});
+
+export default FetchOneArtistApiSpec;

--- a/src/api/spec/artist/UpdateArtistApiSpec.ts
+++ b/src/api/spec/artist/UpdateArtistApiSpec.ts
@@ -1,0 +1,17 @@
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+
+export type UpdateArtistRequest = {
+  name: string,
+  profileImage: string
+}
+
+export type UpdateArtistResponse = {
+  // empty
+}
+
+const UpdateArtistApiSpec = (artistId: number): ApiSpec => ({
+  url: `/admin/api/v1/artists/${artistId}`,
+  method: 'PUT',
+});
+
+export default UpdateArtistApiSpec;

--- a/src/router/RouterPath.ts
+++ b/src/router/RouterPath.ts
@@ -10,6 +10,7 @@ import AdminSchoolManageEditView from '@/views/admin/school/AdminSchoolManageEdi
 import SchoolFestivalManageView from '@/views/school/SchoolFestivalManageView.vue';
 import AdminArtistManageListView from '@/views/admin/artist/AdminArtistManageListView.vue';
 import AdminArtistManageCreateView from '@/views/admin/artist/AdminArtistManageCreateView.vue';
+import AdminArtistManageEditView from '@/views/admin/artist/AdminArtistManageEditView.vue';
 
 const RouterPath = {
   Common: {
@@ -71,6 +72,11 @@ const RouterPath = {
       path: '/admin/artists',
       name: 'adminArtistManageListPage',
       component: AdminArtistManageListView,
+    },
+    AdminArtistManageEditPage: {
+      path: '/admin/artist/edit/:id', // 명시적으로 단수형 사용
+      name: 'adminArtistManageEditPage',
+      component: AdminArtistManageEditView,
     },
   },
   School: {

--- a/src/views/admin/artist/AdminArtistManageEditView.vue
+++ b/src/views/admin/artist/AdminArtistManageEditView.vue
@@ -1,0 +1,178 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { useField, useForm } from 'vee-validate';
+import { useRoute } from 'vue-router';
+import { useSnackbarStore } from '@/stores/useSnackbarStore.ts';
+import FestagoError from '@/api/FestagoError.ts';
+import { router } from '@/router';
+import RouterPath from '@/router/RouterPath.ts';
+import AdminArtistService from '@/api/admin/AdminArtistService.ts';
+import { UpdateArtistRequest } from '@/api/spec/artist/UpdateArtistApiSpec.ts';
+
+const route = useRoute();
+const snackbarStore = useSnackbarStore();
+
+onMounted(() => {
+  AdminArtistService.fetchOneArtist((parseInt(route.params.id as string))).then(response => {
+    const { id, name, profileImage } = response.data;
+    artistId.value = id;
+    nameField.resetField({
+      value: name,
+    });
+    profileImageField.resetField({
+      value: profileImage,
+    });
+  }).catch(e => {
+    if (e instanceof FestagoError) {
+      router.push(RouterPath.Admin.AdminArtistManageListPage.path);
+      snackbarStore.showError('해당 아티스트를 찾을 수 없습니다.');
+    } else throw e;
+  });
+});
+
+const { handleSubmit, isFieldDirty } = useForm<UpdateArtistRequest>({
+  validationSchema: {
+    name(value: string) {
+      if (!value) return '아티스트 이름은 필수입니다.';
+      return true;
+    },
+    profileImage(value: string) {
+      if (!value) return '이미지 URL은 필수입니다.';
+      return true;
+    },
+  },
+});
+
+const onUpdateSubmit = handleSubmit(request => {
+  loading.value = true;
+  setTimeout(() => (loading.value = false), 1000);
+  if (!isFieldDirty('name') && !isFieldDirty('profileImage')) {
+    snackbarStore.showError('아무것도 수정되지 않았습니다.');
+    return;
+  }
+  AdminArtistService.updateArtist(artistId.value!, request).then(() => {
+    loading.value = false;
+    snackbarStore.showSuccess('아티스트가 수정되었습니다.');
+    nameField.resetField({
+      value: nameField.value.value,
+    });
+    profileImageField.resetField({
+      value: profileImageField.value.value,
+    });
+  }).catch(e => {
+    if (e instanceof FestagoError) {
+      snackbarStore.showError(e.message);
+    } else throw e;
+  });
+});
+
+function deleteArtist() {
+  AdminArtistService.deleteArtist(artistId.value!).then(() => {
+    snackbarStore.showSuccess('아티스트가 삭제되었습니다.');
+    router.push(RouterPath.Admin.AdminArtistManageListPage.path);
+  }).catch(e => {
+    if (e instanceof FestagoError) {
+      snackbarStore.showError(e.message);
+    } else throw e;
+  });
+}
+
+const artistId = ref<number>();
+const nameField = useField<string>('name');
+const profileImageField = useField<string>('profileImage');
+const invalidForm = ref(false);
+const loading = ref(false);
+const showDialog = ref(false);
+</script>
+
+<template>
+  <v-dialog
+    v-model="showDialog"
+    max-width="500"
+  >
+    <v-card class="pa-5">
+      <v-card-title class="text-h5 text-center">
+        정말로 삭제할까요?
+      </v-card-title>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn
+          text="취소"
+          color="blue-darken-1"
+          variant="text"
+          @click="showDialog = false"
+        />
+        <v-btn
+          text="삭제"
+          color="red-darken-1"
+          variant="text"
+          @click="deleteArtist"
+        />
+        <v-spacer />
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+  <v-card
+    class="mx-auto pa-3 pa-md-15 py-8 mt-16 w-75"
+    max-width="800"
+    min-width="350"
+    elevation="4"
+  >
+    <v-card-title class="mb-3 text-h4 text-center">
+      아티스트 수정/삭제
+    </v-card-title>
+    <v-form
+      v-model="invalidForm"
+      @submit.prevent="onUpdateSubmit"
+    >
+      <v-text-field
+        class="mb-3"
+        variant="outlined"
+        label="ID"
+        :model-value="artistId"
+        :readonly="true"
+      />
+      <v-text-field
+        class="mb-3"
+        v-model="nameField.value.value"
+        :error-messages="nameField.errorMessage.value"
+        placeholder="아티스트 이름"
+        variant="outlined"
+        label="아티스트 이름"
+      />
+      <v-text-field
+        class="mb-3"
+        v-model="profileImageField.value.value"
+        :error-messages="profileImageField.errorMessage.value"
+        placeholder="https://festa-go.site/image.png"
+        variant="outlined"
+        label="아티스트 이미지 URL"
+      />
+      <v-btn
+        :disabled="!invalidForm"
+        :loading="loading"
+        class="text-h6"
+        type="submit"
+        text="수정"
+        color="blue"
+        :block="true"
+      />
+      <v-btn
+        :disabled="loading"
+        class="text-h6 mt-4"
+        text="삭제"
+        color="red"
+        :block="true"
+        @click="showDialog = true"
+      />
+      <v-btn
+        :disabled="loading"
+        class="text-h6 mt-4"
+        text="취소"
+        color="grey"
+        :block="true"
+        @click="$router.go(-1)"
+      />
+    </v-form>
+  </v-card>
+</template>

--- a/src/views/admin/artist/AdminArtistManageListView.vue
+++ b/src/views/admin/artist/AdminArtistManageListView.vue
@@ -10,6 +10,7 @@ const tableHeaders = [
   { title: 'ID', key: 'id' },
   { title: '이름', key: 'name' },
   { title: '프로필 URL', key: 'profileImage' },
+  { title: '수정/삭제', key: 'actions', sortable: false },
 ];
 
 const itemsPerPageOptions = [
@@ -30,7 +31,6 @@ function fetch() {
     loading.value = false;
   });
 }
-
 </script>
 
 <template>
@@ -46,7 +46,7 @@ function fetch() {
       :fetch="fetch"
       :item-length="items.length"
       :items="items"
-      :detail-page-router-name="RouterPath.Admin.AdminSchoolManageEditPage.name"
+      :detail-page-router-name="RouterPath.Admin.AdminArtistManageEditPage.name"
     />
   </v-card>
 </template>


### PR DESCRIPTION
## DONE

![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/9e8469e3-02b0-4a70-8bc3-62aec5851861)

## TODO

- 수정/삭제 페이지에 사용되는 Form 컴포넌트로 분리하여 재사용성 확보