### PR TITLE
feat: 생성 폼 컴포넌트 분리 (#44)

### DIFF
--- a/src/components/form/CreateForm.vue
+++ b/src/components/form/CreateForm.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const props = defineProps<{
+  onSubmit: (e?: Event) => Promise<void | undefined>,
+  formTitle: string,
+  loading: boolean
+}>();
+const invalidForm = ref(false);
+
+</script>
+
+<template>
+  <v-form
+    v-model="invalidForm"
+    @submit.prevent="props.onSubmit"
+  >
+    <v-card
+      class="mx-auto pa-3 pa-md-15 py-8 mt-16 w-75"
+      max-width="800"
+      min-width="350"
+      elevation="4"
+    >
+      <v-card-title class="mb-3">
+        <p class="text-h4 text-center">
+          {{ props.formTitle }}
+        </p>
+      </v-card-title>
+      <slot />
+      <v-btn
+        :disabled="!invalidForm"
+        :loading="props.loading"
+        class="text-h6"
+        type="submit"
+        text="생성"
+        color="blue"
+        :block="true"
+      />
+    </v-card>
+  </v-form>
+</template>

--- a/src/views/admin/artist/AdminArtistManageCreateView.vue
+++ b/src/views/admin/artist/AdminArtistManageCreateView.vue
@@ -6,6 +6,7 @@ import { useField, useForm } from 'vee-validate';
 import { CreateArtistRequest } from '@/api/spec/artist/CreateArtistApiSpec.ts';
 import AdminArtistService from '@/api/admin/AdminArtistService.ts';
 import FestagoError from '@/api/FestagoError.ts';
+import CreateForm from '@/components/form/CreateForm.vue';
 
 const snackbarStore = useSnackbarStore();
 const { handleSubmit, handleReset } = useForm<CreateArtistRequest>({
@@ -23,7 +24,6 @@ const { handleSubmit, handleReset } = useForm<CreateArtistRequest>({
 
 const nameField = useField('name');
 const profileImageField = useField('profileImage');
-const invalidForm = ref(false);
 const loading = ref(false);
 
 const onSubmit = handleSubmit(request => {
@@ -42,46 +42,26 @@ const onSubmit = handleSubmit(request => {
 </script>
 
 <template>
-  <v-card
-    class="mx-auto pa-3 pa-md-15 py-8 mt-16 w-75"
-    max-width="800"
-    min-width="350"
-    elevation="4"
+  <CreateForm
+    :on-submit="onSubmit"
+    :loading="loading"
+    form-title="아티스트 추가"
   >
-    <v-card-title class="mb-3">
-      <p class="text-h4 text-center">
-        아티스트 추가
-      </p>
-    </v-card-title>
-    <v-form
-      v-model="invalidForm"
-      @submit.prevent="onSubmit"
-    >
-      <v-text-field
-        class="mb-3"
-        v-model="nameField.value.value"
-        :error-messages="nameField.errorMessage.value"
-        placeholder="아티스트 이름"
-        variant="outlined"
-        label="아티스트 이름"
-      />
-      <v-text-field
-        class="mb-3"
-        v-model="profileImageField.value.value"
-        :error-messages="profileImageField.errorMessage.value"
-        placeholder="https://festa-go.site/image.png"
-        variant="outlined"
-        label="아티스트 이미지 URL"
-      />
-      <v-btn
-        :disabled="!invalidForm"
-        :loading="loading"
-        class="text-h6"
-        type="submit"
-        text="생성"
-        color="blue"
-        :block="true"
-      />
-    </v-form>
-  </v-card>
+    <v-text-field
+      class="mb-3"
+      v-model="nameField.value.value"
+      :error-messages="nameField.errorMessage.value"
+      placeholder="아티스트 이름"
+      variant="outlined"
+      label="아티스트 이름"
+    />
+    <v-text-field
+      class="mb-3"
+      v-model="profileImageField.value.value"
+      :error-messages="profileImageField.errorMessage.value"
+      placeholder="https://festa-go.site/image.png"
+      variant="outlined"
+      label="아티스트 이미지 URL"
+    />
+  </CreateForm>
 </template>

--- a/src/views/admin/school/AdminSchoolManageCreateView.vue
+++ b/src/views/admin/school/AdminSchoolManageCreateView.vue
@@ -5,6 +5,7 @@ import { ref } from 'vue';
 import { useSnackbarStore } from '@/stores/useSnackbarStore.ts';
 import FestagoError from '@/api/FestagoError.ts';
 import { CreateSchoolRequest } from '@/api/spec/school/CreateSchoolApiSpec.ts';
+import CreateForm from '@/components/form/CreateForm.vue';
 
 const snackbarStore = useSnackbarStore();
 const { handleSubmit, handleReset } = useForm<CreateSchoolRequest>({
@@ -12,7 +13,7 @@ const { handleSubmit, handleReset } = useForm<CreateSchoolRequest>({
     name(value: string) {
       if (!value) return '대학교 이름은 필수입니다.';
       if (value.length < 5) return '대학교의 이름은 5글자 이상이어야 합니다.';
-      if (!value.endsWith("학교")) return '대학교의 이름은 "학교"로 끝나야 합니다.';
+      if (!value.endsWith('학교')) return '대학교의 이름은 "학교"로 끝나야 합니다.';
       return true;
     },
     domain(value: string) {
@@ -26,7 +27,6 @@ const { handleSubmit, handleReset } = useForm<CreateSchoolRequest>({
 });
 const nameField = useField('name');
 const domainField = useField('domain');
-const invalidForm = ref(false);
 const loading = ref(false);
 
 const onSubmit = handleSubmit(request => {
@@ -45,46 +45,26 @@ const onSubmit = handleSubmit(request => {
 </script>
 
 <template>
-  <v-card
-    class="mx-auto pa-3 pa-md-15 py-8 mt-16 w-75"
-    max-width="800"
-    min-width="350"
-    elevation="4"
+  <CreateForm
+    :on-submit="onSubmit"
+    form-title="학교 추가"
+    :loading="loading"
   >
-    <v-card-title class="mb-3">
-      <p class="text-h4 text-center">
-        학교 추가
-      </p>
-    </v-card-title>
-    <v-form
-      v-model="invalidForm"
-      @submit.prevent="onSubmit"
-    >
-      <v-text-field
-        class="mb-3"
-        v-model="nameField.value.value"
-        :error-messages="nameField.errorMessage.value"
-        placeholder="XX대학교"
-        variant="outlined"
-        label="대학교 이름"
-      />
-      <v-text-field
-        class="mb-3"
-        v-model="domainField.value.value"
-        :error-messages="domainField.errorMessage.value"
-        placeholder="school.ac.kr"
-        variant="outlined"
-        label="학교 도메인"
-      />
-      <v-btn
-        :disabled="!invalidForm"
-        :loading="loading"
-        class="text-h6"
-        type="submit"
-        text="생성"
-        color="blue"
-        :block="true"
-      />
-    </v-form>
-  </v-card>
+    <v-text-field
+      class="mb-3"
+      v-model="nameField.value.value"
+      :error-messages="nameField.errorMessage.value"
+      placeholder="XX대학교"
+      variant="outlined"
+      label="대학교 이름"
+    />
+    <v-text-field
+      class="mb-3"
+      v-model="domainField.value.value"
+      :error-messages="domainField.errorMessage.value"
+      placeholder="school.ac.kr"
+      variant="outlined"
+      label="학교 도메인"
+    />
+  </CreateForm>
 </template>


### PR DESCRIPTION
## DONE

### CreateForm.vue
```vue
<template>
  <v-form
    v-model="invalidForm"
    @submit.prevent="props.onSubmit"
  >
    <v-card
      class="mx-auto pa-3 pa-md-15 py-8 mt-16 w-75"
      max-width="800"
      min-width="350"
      elevation="4"
    >
      <v-card-title class="mb-3">
        <p class="text-h4 text-center">
          {{ props.formTitle }}
        </p>
      </v-card-title>
      <slot />
      <v-btn
        :disabled="!invalidForm"
        :loading="props.loading"
        class="text-h6"
        type="submit"
        text="생성"
        color="blue"
        :block="true"
      />
    </v-card>
  </v-form>
</template>
```

### AdminSchoolManageCreateView.vue
```vue
<template>
  <CreateForm
    :on-submit="onSubmit"
    form-title="학교 추가"
    :loading="loading"
  >
    <v-text-field
      class="mb-3"
      v-model="nameField.value.value"
      :error-messages="nameField.errorMessage.value"
      placeholder="XX대학교"
      variant="outlined"
      label="대학교 이름"
    />
    <v-text-field
      class="mb-3"
      v-model="domainField.value.value"
      :error-messages="domainField.errorMessage.value"
      placeholder="school.ac.kr"
      variant="outlined"
      label="학교 도메인"
    />
  </CreateForm>
</template>
```

## TODO

- CreateForm Slot을 지정할 때 보일러 플레이트 코드가 삽입되는데, 필요한 특정 속성만 list로 전달하여, 생성되게 하면 좋을 것 같음