### PR TITLE
feat: 축제 생성 페이지 추가 (#22)

### DIFF
--- a/src/api/admin/AdminFestivalService.ts
+++ b/src/api/admin/AdminFestivalService.ts
@@ -1,0 +1,13 @@
+import CreateFestivalApiSpec, {
+  CreateFestivalRequest,
+  CreateFestivalResponse,
+} from '@/api/spec/festival/CreateFestivalApiSpec.ts';
+import ApiService from '@/api';
+
+const AdminFestivalService = {
+  createFestival(request: CreateFestivalRequest) {
+    return ApiService.request<CreateFestivalResponse>(CreateFestivalApiSpec, request);
+  },
+};
+
+export default AdminFestivalService;

--- a/src/api/spec/festival/CreateFestivalApiSpec.ts
+++ b/src/api/spec/festival/CreateFestivalApiSpec.ts
@@ -1,0 +1,20 @@
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+
+export type CreateFestivalRequest = {
+  name: string,
+  startDate: string,
+  endDate: string,
+  posterImageUrl: string,
+  schoolId: number
+}
+
+export type CreateFestivalResponse = {
+  // empty
+}
+
+const CreateFestivalApiSpec: ApiSpec = {
+  url: '/admin/api/v1/festivals',
+  method: 'POST',
+};
+
+export default CreateFestivalApiSpec;

--- a/src/api/spec/school/FetchSchoolsApiSpec.ts
+++ b/src/api/spec/school/FetchSchoolsApiSpec.ts
@@ -1,16 +1,12 @@
 import ApiSpec from '@/api/spec/ApiSpec.ts';
+import { FetchOneSchoolResponse } from '@/api/spec/school/FetchOneSchoolApiSpec.ts';
 
 export type FetchSchoolsRequest = {
   // empty
 }
 
 export type FetchSchoolsResponse = {
-  content: {
-    id: number,
-    domain: string,
-    name: string,
-    region: string,
-  }[],
+  content: FetchOneSchoolResponse[],
   totalElements: number
 }
 

--- a/src/components/navigation/drawer/AdminDrawerItems.vue
+++ b/src/components/navigation/drawer/AdminDrawerItems.vue
@@ -66,5 +66,18 @@ const menus = ref([]);
         @click="$router.push(RouterPath.Admin.AdminArtistManageListPage.path)"
       />
     </v-list-group>
+    <v-list-group>
+      <template v-slot:activator="{ props }">
+        <v-list-item
+          v-bind="props"
+          prepend-icon="mdi-party-popper"
+          title="축제 관리"
+        ></v-list-item>
+      </template>
+      <v-list-item
+        title="축제 추가"
+        @click="$router.push(RouterPath.Admin.AdminFestivalManageCreatePage.path)"
+      />
+    </v-list-group>
   </v-list>
 </template>

--- a/src/router/RouterPath.ts
+++ b/src/router/RouterPath.ts
@@ -4,13 +4,13 @@ import RootAdminView from '@/views/root/RootAdminView.vue';
 import AdminMyPageView from '@/views/admin/AdminMyPageView.vue';
 import AdminSchoolManageListView from '@/views/admin/school/AdminSchoolManageListView.vue';
 import NotFoundView from '@/views/common/NotFoundView.vue';
-import AdminFestivalManageView from '@/views/admin/AdminFestivalManageView.vue';
 import AdminSchoolManageCreateView from '@/views/admin/school/AdminSchoolManageCreateView.vue';
 import AdminSchoolManageEditView from '@/views/admin/school/AdminSchoolManageEditView.vue';
 import SchoolFestivalManageView from '@/views/school/SchoolFestivalManageView.vue';
 import AdminArtistManageListView from '@/views/admin/artist/AdminArtistManageListView.vue';
 import AdminArtistManageCreateView from '@/views/admin/artist/AdminArtistManageCreateView.vue';
 import AdminArtistManageEditView from '@/views/admin/artist/AdminArtistManageEditView.vue';
+import AdminFestivalManageCreateView from '@/views/admin/festival/AdminFestivalManageCreateView.vue';
 
 const RouterPath = {
   Common: {
@@ -58,11 +58,6 @@ const RouterPath = {
       name: 'adminSchoolManageEditPage',
       component: AdminSchoolManageEditView,
     },
-    AdminFestivalManagePage: {
-      path: '/admin/festivals',
-      name: 'adminFestivalManagePage',
-      component: AdminFestivalManageView,
-    },
     AdminArtistManageCreatePage: {
       path: '/admin/artist/create', // 명시적으로 단수형 사용
       name: 'adminArtistManageCreatePage',
@@ -77,6 +72,11 @@ const RouterPath = {
       path: '/admin/artist/edit/:id', // 명시적으로 단수형 사용
       name: 'adminArtistManageEditPage',
       component: AdminArtistManageEditView,
+    },
+    AdminFestivalManageCreatePage: {
+      path: '/admin/festival/create', // 명시적으로 단수형 사용
+      name: 'adminFestivalManageCreatePage',
+      component: AdminFestivalManageCreateView,
     },
   },
   School: {

--- a/src/views/admin/AdminFestivalManageView.vue
+++ b/src/views/admin/AdminFestivalManageView.vue
@@ -1,7 +1,0 @@
-<script setup lang="ts">
-
-</script>
-
-<template>
-  <h1>관리자가 축제를 관리하는 페이지</h1>
-</template>

--- a/src/views/admin/festival/AdminFestivalManageCreateView.vue
+++ b/src/views/admin/festival/AdminFestivalManageCreateView.vue
@@ -1,0 +1,194 @@
+<script setup lang="ts">
+import CreateForm from '@/components/form/CreateForm.vue';
+import { ref } from 'vue';
+import { useField, useForm } from 'vee-validate';
+import AdminSchoolService from '@/api/admin/AdminSchoolService.ts';
+import { FetchOneSchoolResponse } from '@/api/spec/school/FetchOneSchoolApiSpec.ts';
+import { useSnackbarStore } from '@/stores/useSnackbarStore.ts';
+import { CreateFestivalRequest } from '@/api/spec/festival/CreateFestivalApiSpec.ts';
+
+const snackbarStore = useSnackbarStore();
+const { handleSubmit, handleReset } = useForm<CreateFestivalRequest>({
+  validationSchema: {
+    schoolId(value: string) {
+      if (!value) return '학교는 필수입니다.';
+      return true;
+    },
+    name(value: string) {
+      if (!value) return '축제 이름은 필수입니다.';
+      if (value.length < 5) return '축제 이름은 5글자 이상이어야 합니다.';
+      return true;
+    },
+    startDate(value: string) {
+      if (!value) return '시작일은 필수입니다.';
+      return true;
+    },
+    endDate(value: string) {
+      if (!value) return '시작일은 필수입니다.';
+      return true;
+    },
+    posterImageUrl(value: string) {
+      if (!value) return '포스터 이미지 URL은 필수입니다.';
+      if (value.length >= 255) return '포스터 이미지 URL은 255글자 미만이어야 합니다.'
+      if (!value.startsWith("https://")) return '포스터 이미지 URL은 https://로 시작되어야 합니다.'
+      if (!/\.(png|jpg)$/.test(value)) return '포스터 이미지 URL은 png,jpg와 같은 이미지 파일으로 끝나야 합니다.'
+      return true;
+    },
+  },
+});
+const nameField = useField('name');
+const schoolIdField = useField('schoolId');
+const startDateField = useField('startDate');
+const endDateField = useField('endDate');
+const posterImageUrlField = useField('posterImageUrl');
+
+const schools = ref<FetchOneSchoolResponse[]>([]);
+const fakeSchoolName = ref<string>('');
+const loading = ref(false);
+const fetchSchoolsLoading = ref(false);
+const showSchoolSelectDialog = ref(false);
+const schoolSearchKeyword = ref('');
+const onSubmit = handleSubmit(request => {
+  console.log(request);
+  handleReset();
+  snackbarStore.showSuccess('축제가 생성되었습니다!');
+});
+
+function fetchSchools() {
+  fetchSchoolsLoading.value = true;
+  setTimeout(() => (fetchSchoolsLoading.value = false), 500);
+  AdminSchoolService.fetchSchools({
+    page: 1,
+    itemsPerPage: 10,
+    sortBy: [],
+  }, {
+    searchKeyword: schoolSearchKeyword.value,
+    searchFilter: 'name',
+  }).then(response => {
+    schools.value = response.data.content;
+  });
+}
+
+function selectSchool(school: FetchOneSchoolResponse) {
+  fakeSchoolName.value = school.name;
+  schoolIdField.setValue(school.id);
+  showSchoolSelectDialog.value = false;
+}
+
+</script>
+
+<template>
+  <v-dialog
+    v-model="showSchoolSelectDialog"
+    max-width="500"
+  >
+    <v-card class="pa-5">
+      <v-card-title class="text-h5 text-center">
+        학교 선택
+      </v-card-title>
+
+      <v-row :no-gutters="true" align="center">
+        <v-col :cols="10">
+          <v-text-field
+            class="pa-2 ma-2"
+            v-model="schoolSearchKeyword"
+            label="학교 이름"
+            prepend-inner-icon="mdi-magnify"
+            :single-line="true"
+            variant="outlined"
+            :hide-details="true"
+            maxLength="50"
+          />
+        </v-col>
+        <v-col :cols="2">
+          <v-btn
+            :loading="fetchSchoolsLoading"
+            :disabled="!(!!(schoolSearchKeyword))"
+            class="py-7 text-h6"
+            color="blue"
+            variant="flat"
+            :block="true"
+            text="검색"
+            @click="fetchSchools"
+          />
+        </v-col>
+      </v-row>
+
+      <v-table class="text-center">
+        <thead>
+        <tr>
+          <th id="name" class="text-center">
+            이름
+          </th>
+          <th id="selectBtn" class="text-center" />
+        </tr>
+        </thead>
+        <tbody>
+        <tr
+          v-for="item in schools"
+          :key="item.id"
+        >
+          <td>{{ item.name }}</td>
+          <td>
+            <v-btn
+              @click="selectSchool(item)"
+              text="선택"
+            />
+          </td>
+        </tr>
+        </tbody>
+      </v-table>
+    </v-card>
+  </v-dialog>
+  <CreateForm
+    :on-submit="onSubmit"
+    :loading="loading"
+    form-title="축제 추가"
+  >
+    <v-text-field
+      @click="showSchoolSelectDialog = true"
+      :readonly="true"
+      :error-messages="schoolIdField.errorMessage.value"
+      v-model="fakeSchoolName"
+      variant="outlined"
+      label="학교를 선택해주세요."
+    />
+    <input
+      v-model="schoolIdField.value.value"
+      type="text"
+      hidden="hidden"
+    >
+    <v-text-field
+      class="mb-3"
+      v-model="nameField.value.value"
+      :error-messages="nameField.errorMessage.value"
+      placeholder="축제 이름"
+      variant="outlined"
+      label="축제 이름"
+    />
+    <v-text-field
+      class="mb-3"
+      type="date"
+      v-model="startDateField.value.value"
+      :error-messages="startDateField.errorMessage.value"
+      variant="outlined"
+      label="축제 시작일"
+    />
+    <v-text-field
+      class="mb-3"
+      type="date"
+      v-model="endDateField.value.value"
+      :error-messages="endDateField.errorMessage.value"
+      variant="outlined"
+      label="축제 종료일"
+    />
+    <v-text-field
+      class="mb-3"
+      v-model="posterImageUrlField.value.value"
+      :error-messages="posterImageUrlField.errorMessage.value"
+      placeholder="https://image.com/festival-poseter.png"
+      variant="outlined"
+      label="축제 포스터 이미지 URL"
+    />
+  </CreateForm>
+</template>

--- a/src/views/admin/festival/AdminFestivalManageCreateView.vue
+++ b/src/views/admin/festival/AdminFestivalManageCreateView.vue
@@ -6,6 +6,8 @@ import AdminSchoolService from '@/api/admin/AdminSchoolService.ts';
 import { FetchOneSchoolResponse } from '@/api/spec/school/FetchOneSchoolApiSpec.ts';
 import { useSnackbarStore } from '@/stores/useSnackbarStore.ts';
 import { CreateFestivalRequest } from '@/api/spec/festival/CreateFestivalApiSpec.ts';
+import AdminFestivalService from '@/api/admin/AdminFestivalService.ts';
+import FestagoError from '@/api/FestagoError.ts';
 
 const snackbarStore = useSnackbarStore();
 const { handleSubmit, handleReset } = useForm<CreateFestivalRequest>({
@@ -49,9 +51,17 @@ const fetchSchoolsLoading = ref(false);
 const showSchoolSelectDialog = ref(false);
 const schoolSearchKeyword = ref('');
 const onSubmit = handleSubmit(request => {
-  console.log(request);
-  handleReset();
-  snackbarStore.showSuccess('축제가 생성되었습니다!');
+  loading.value = true;
+  setTimeout(() => (loading.value = false), 1000);
+  AdminFestivalService.createFestival(request).then(()=>{
+    handleReset();
+    loading.value = false;
+    snackbarStore.showSuccess('축제가 생성되었습니다!');
+  }).catch(e => {
+    if (e instanceof FestagoError) {
+      snackbarStore.showError(e.message);
+    } else throw e;
+  });
 });
 
 function fetchSchools() {

--- a/src/views/admin/festival/AdminFestivalManageCreateView.vue
+++ b/src/views/admin/festival/AdminFestivalManageCreateView.vue
@@ -135,13 +135,13 @@ function selectSchool(school: FetchOneSchoolResponse) {
         </thead>
         <tbody>
         <tr
-          v-for="item in schools"
-          :key="item.id"
+          v-for="school in schools"
+          :key="school.id"
         >
-          <td>{{ item.name }}</td>
+          <td>{{ school.name }}</td>
           <td>
             <v-btn
-              @click="selectSchool(item)"
+              @click="selectSchool(school)"
               text="선택"
             />
           </td>


### PR DESCRIPTION
## DONE

![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/ca40656c-bf95-4ab8-9b39-9b657e63c481)

![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/48553b07-1bf4-4a36-bf9e-59de712efb91)

## TODO

- 축제 조회 페이지 추가
- 아직 백엔드 축제 생성 API가 완성되지 않았으므로 빠르게 완성할 것
- 학교 선택에 관한 태그를 컴포넌트로 분리하여 재사용성 확보
