### PR TITLE
fix: 축제 생성 페이지에서 종료일 검증 메시지 수정 (#73)

### DIFF
--- a/src/views/admin/festival/AdminFestivalManageCreateView.vue
+++ b/src/views/admin/festival/AdminFestivalManageCreateView.vue
@@ -26,7 +26,7 @@ const { handleSubmit, handleReset } = useForm<CreateFestivalRequest>({
       return true;
     },
     endDate(value: string) {
-      if (!value) return '시작일은 필수입니다.';
+      if (!value) return '종료일은 필수입니다.';
       return true;
     },
     posterImageUrl(value: string) {


### PR DESCRIPTION
### 관련 이슈
#73 

## DONE

![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/772de1bb-ce13-4d7f-ab11-1bd2bb3b17d4)


