### PR TITLE
아티스트 생성/수정 페이지 backgroundImageUrl 추가 (#76)

### DIFF
--- a/src/api/spec/artist/CreateArtistApiSpec.ts
+++ b/src/api/spec/artist/CreateArtistApiSpec.ts
@@ -2,7 +2,8 @@ import ApiSpec from '@/api/spec/ApiSpec.ts';
 
 export type CreateArtistRequest = {
   name: string,
-  profileImage: string
+  profileImage: string,
+  backgroundImageUrl: string
 }
 
 export type CreateArtistResponse = {

--- a/src/api/spec/artist/UpdateArtistApiSpec.ts
+++ b/src/api/spec/artist/UpdateArtistApiSpec.ts
@@ -2,7 +2,8 @@ import ApiSpec from '@/api/spec/ApiSpec.ts';
 
 export type UpdateArtistRequest = {
   name: string,
-  profileImage: string
+  profileImage: string,
+  backgroundImageUrl: string
 }
 
 export type UpdateArtistResponse = {

--- a/src/views/admin/artist/AdminArtistManageCreateView.vue
+++ b/src/views/admin/artist/AdminArtistManageCreateView.vue
@@ -16,14 +16,19 @@ const { handleSubmit, handleReset } = useForm<CreateArtistRequest>({
       return true;
     },
     profileImage(value: string) {
-      if (!value) return '이미지 URL는 필수입니다.';
+      if (!value) return '프로필 이미지 URL은 필수입니다.';
+      return true;
+    },
+    backgroundImageUrl(value: string) {
+      if (!value) return '백그라운드 이미지 URL은 필수입니다.';
       return true;
     },
   },
 });
 
 const nameField = useField('name');
-const profileImageField = useField('profileImage');
+const profileImageUrlField = useField('profileImage');
+const backgroundImageUrlField = useField('backgroundImageUrl');
 const loading = ref(false);
 
 const onSubmit = handleSubmit(request => {
@@ -57,11 +62,19 @@ const onSubmit = handleSubmit(request => {
     />
     <v-text-field
       class="mb-3"
-      v-model="profileImageField.value.value"
-      :error-messages="profileImageField.errorMessage.value"
+      v-model="profileImageUrlField.value.value"
+      :error-messages="profileImageUrlField.errorMessage.value"
       placeholder="https://festa-go.site/image.png"
       variant="outlined"
-      label="아티스트 이미지 URL"
+      label="아티스트 프로필 이미지 URL"
+    />
+    <v-text-field
+      class="mb-3"
+      v-model="backgroundImageUrlField.value.value"
+      :error-messages="backgroundImageUrlField.errorMessage.value"
+      placeholder="https://festa-go.site/image.png"
+      variant="outlined"
+      label="아티스트 백그라운드 이미지 URL"
     />
   </CreateForm>
 </template>

--- a/src/views/admin/artist/AdminArtistManageEditView.vue
+++ b/src/views/admin/artist/AdminArtistManageEditView.vue
@@ -9,12 +9,14 @@ import RouterPath from '@/router/RouterPath.ts';
 import AdminArtistService from '@/api/admin/AdminArtistService.ts';
 import { UpdateArtistRequest } from '@/api/spec/artist/UpdateArtistApiSpec.ts';
 import EditForm from '@/components/form/EditForm.vue';
+import { allTrue } from '@/utils/BooleanUtils.ts';
 
 const route = useRoute();
 const snackbarStore = useSnackbarStore();
 
 onMounted(() => {
   AdminArtistService.fetchOneArtist((parseInt(route.params.id as string))).then(response => {
+    // TODO 백엔드 아티스트 조회에 backgroundImageUrl을 추가해야함
     const { id, name, profileImage } = response.data;
     artistId.value = id;
     nameField.resetField({
@@ -22,6 +24,9 @@ onMounted(() => {
     });
     profileImageField.resetField({
       value: profileImage,
+    });
+    backgroundImageUrlField.resetField({
+      value: '',
     });
   }).catch(e => {
     if (e instanceof FestagoError) {
@@ -38,7 +43,11 @@ const { handleSubmit, isFieldDirty } = useForm<UpdateArtistRequest>({
       return true;
     },
     profileImage(value: string) {
-      if (!value) return '이미지 URL은 필수입니다.';
+      if (!value) return '프로필 이미지 URL은 필수입니다.';
+      return true;
+    },
+    backgroundImageUrl(value: string) {
+      if (!value) return '백그라운드 이미지 URL은 필수입니다.';
       return true;
     },
   },
@@ -47,7 +56,11 @@ const { handleSubmit, isFieldDirty } = useForm<UpdateArtistRequest>({
 const onUpdateSubmit = handleSubmit(request => {
   loading.value = true;
   setTimeout(() => (loading.value = false), 1000);
-  if (!isFieldDirty('name') && !isFieldDirty('profileImage')) {
+  if (allTrue(
+    !isFieldDirty('name'),
+    !isFieldDirty('profileImage'),
+    !isFieldDirty('backgroundImageUrl'),
+  )) {
     snackbarStore.showError('아무것도 수정되지 않았습니다.');
     return;
   }
@@ -59,6 +72,9 @@ const onUpdateSubmit = handleSubmit(request => {
     });
     profileImageField.resetField({
       value: profileImageField.value.value,
+    });
+    backgroundImageUrlField.resetField({
+      value: backgroundImageUrlField.value.value,
     });
   }).catch(e => {
     if (e instanceof FestagoError) {
@@ -81,6 +97,7 @@ function onDeleteSubmit() {
 const artistId = ref<number>();
 const nameField = useField<string>('name');
 const profileImageField = useField<string>('profileImage');
+const backgroundImageUrlField = useField<string>('backgroundImageUrl');
 const loading = ref(false);
 </script>
 
@@ -110,9 +127,17 @@ const loading = ref(false);
       class="mb-3"
       v-model="profileImageField.value.value"
       :error-messages="profileImageField.errorMessage.value"
-      placeholder="https://festa-go.site/image.png"
+      placeholder="https://festa-go.site/profile-image.png"
       variant="outlined"
-      label="아티스트 이미지 URL"
+      label="아티스트 프로필 이미지 URL"
+    />
+    <v-text-field
+      class="mb-3"
+      v-model="backgroundImageUrlField.value.value"
+      :error-messages="backgroundImageUrlField.errorMessage.value"
+      placeholder="https://festa-go.site/background-image.png"
+      variant="outlined"
+      label="아티스트 백그라운드 이미지 URL"
     />
   </EditForm>
 </template>


### PR DESCRIPTION
## DONE

![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/2502204f-ac91-462d-b7bb-d54ae8a693bc)

![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/be13f644-b7d9-47b2-8043-3d8a5ffb9cff)

## TODO

- 백엔드 아티스트 조회 시 backgroundImageUrl가 없어서 조회, 수정에 문제가 발생함