### PR TITLE
축제 상세 페이지 분리 및 공연 추가 페이지 추가 (#75)

### DIFF
--- a/src/api/admin/AdminStageService.ts
+++ b/src/api/admin/AdminStageService.ts
@@ -1,0 +1,10 @@
+import CreateStageApiSpec, { CreateStageRequest, CreateStageResponse } from '@/api/spec/stage/CreateStageApiSpec.ts';
+import ApiService from '@/api';
+
+const AdminStageService = {
+  createStage(request: CreateStageRequest) {
+    return ApiService.request<CreateStageResponse>(CreateStageApiSpec, request)
+  }
+}
+
+export default AdminStageService;

--- a/src/api/spec/stage/CreateStageApiSpec.ts
+++ b/src/api/spec/stage/CreateStageApiSpec.ts
@@ -1,0 +1,19 @@
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+
+export type CreateStageRequest = {
+  festivalId: number,
+  startTime: string,
+  ticketOpenTime: string,
+  artistIds: number[]
+}
+
+export type CreateStageResponse = {
+  // empty
+}
+
+const CreateStageApiSpec: ApiSpec = {
+  url: '/admin/api/v1/stages',
+  method: 'POST',
+};
+
+export default CreateStageApiSpec;

--- a/src/router/RouterPath.ts
+++ b/src/router/RouterPath.ts
@@ -92,7 +92,7 @@ const RouterPath = {
       component: AdminFestivalManageDetailView,
     },
     AdminFestivalManageEditPage: {
-      path: '/admin/festival/edit/:id',
+      path: '/admin/festivals/:id/edit',
       name: 'adminFestivalManageEditPage',
       component: AdminFestivalManageEditView,
     },

--- a/src/router/RouterPath.ts
+++ b/src/router/RouterPath.ts
@@ -14,6 +14,7 @@ import AdminFestivalManageCreateView from '@/views/admin/festival/AdminFestivalM
 import AdminFestivalManageListView from '@/views/admin/festival/AdminFestivalManageListView.vue';
 import AdminFestivalManageEditView from '@/views/admin/festival/AdminFestivalManageEditView.vue';
 import AdminFestivalManageDetailView from '@/views/admin/festival/AdminFestivalManageDetailView.vue';
+import AdminStageManageCreateView from '@/views/admin/stage/AdminStageManageCreateView.vue';
 
 const RouterPath = {
   Common: {
@@ -95,6 +96,11 @@ const RouterPath = {
       path: '/admin/festivals/:id/edit',
       name: 'adminFestivalManageEditPage',
       component: AdminFestivalManageEditView,
+    },
+    AdminStageManageCreatePage: {
+      path: '/admin/festivals/:id/stage/create',
+      name: 'adminStageManageCreatePage',
+      component: AdminStageManageCreateView,
     },
   },
   School: {

--- a/src/router/RouterPath.ts
+++ b/src/router/RouterPath.ts
@@ -13,6 +13,7 @@ import AdminArtistManageEditView from '@/views/admin/artist/AdminArtistManageEdi
 import AdminFestivalManageCreateView from '@/views/admin/festival/AdminFestivalManageCreateView.vue';
 import AdminFestivalManageListView from '@/views/admin/festival/AdminFestivalManageListView.vue';
 import AdminFestivalManageEditView from '@/views/admin/festival/AdminFestivalManageEditView.vue';
+import AdminFestivalManageDetailView from '@/views/admin/festival/AdminFestivalManageDetailView.vue';
 
 const RouterPath = {
   Common: {
@@ -84,6 +85,11 @@ const RouterPath = {
       path: '/admin/festivals',
       name: 'adminFestivalManageListPage',
       component: AdminFestivalManageListView,
+    },
+    AdminFestivalManageDetailView: {
+      path: '/admin/festivals/:id',
+      name: 'adminFestivalManageDetailPage',
+      component: AdminFestivalManageDetailView,
     },
     AdminFestivalManageEditPage: {
       path: '/admin/festival/edit/:id',

--- a/src/views/admin/festival/AdminFestivalManageDetailView.vue
+++ b/src/views/admin/festival/AdminFestivalManageDetailView.vue
@@ -11,11 +11,11 @@ import RouterPath from '@/router/RouterPath.ts';
     </h1>
 
     <div>
-      <h3 class="my-2 pt-5">
-        축제 정보
-      </h3>
       <v-row>
-        <v-col :cols="6">
+        <v-col :cols="5">
+          <h3 class="my-2 pt-5">
+            축제 정보
+          </h3>
           <v-card>
             <v-card-item
               class="px-8 py-2"
@@ -64,6 +64,38 @@ import RouterPath from '@/router/RouterPath.ts';
               </div>
             </v-card-item>
           </v-card>
+        </v-col>
+        <v-col :cols="7">
+          <h3 class="my-2 pt-5">
+            공연 정보
+          </h3>
+          <v-table>
+            <thead>
+              <tr>
+                <th>
+                  시작 시간
+                </th>
+                <th>
+                  티켓 오픈 시간
+                </th>
+                <th>
+                  아티스트 목록
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>2077-06-30T18:00:00</td>
+                <td>2077-06-30T18:00:00</td>
+                <td>장기하,아이유,에픽하이,장기하,아이유,에픽하이</td>
+              </tr>
+              <tr>
+                <td>2077-06-30T18:00:00</td>
+                <td>2077-06-30T18:00:00</td>
+                <td>장기하,아이유,에픽하이</td>
+              </tr>
+            </tbody>
+          </v-table>
         </v-col>
       </v-row>
     </div>

--- a/src/views/admin/festival/AdminFestivalManageDetailView.vue
+++ b/src/views/admin/festival/AdminFestivalManageDetailView.vue
@@ -97,6 +97,7 @@ import RouterPath from '@/router/RouterPath.ts';
           <v-card
             class="py-2"
             variant="outlined"
+            @click="$router.push(RouterPath.Admin.AdminStageManageCreatePage)"
           >
             <v-card-item>
               <span class="mdi mdi-plus-box-multiple-outline" />

--- a/src/views/admin/festival/AdminFestivalManageDetailView.vue
+++ b/src/views/admin/festival/AdminFestivalManageDetailView.vue
@@ -71,29 +71,29 @@ import RouterPath from '@/router/RouterPath.ts';
           </h3>
           <v-table>
             <thead>
-              <tr>
-                <th>
-                  시작 시간
-                </th>
-                <th>
-                  티켓 오픈 시간
-                </th>
-                <th>
-                  아티스트 목록
-                </th>
-              </tr>
+            <tr>
+              <th id="startTime">
+                시작 시간
+              </th>
+              <th id="ticketOpenTime">
+                티켓 오픈 시간
+              </th>
+              <th id="artists">
+                아티스트 목록
+              </th>
+            </tr>
             </thead>
             <tbody>
-              <tr>
-                <td>2077-06-30T18:00:00</td>
-                <td>2077-06-30T18:00:00</td>
-                <td>장기하,아이유,에픽하이,장기하,아이유,에픽하이</td>
-              </tr>
-              <tr>
-                <td>2077-06-30T18:00:00</td>
-                <td>2077-06-30T18:00:00</td>
-                <td>장기하,아이유,에픽하이</td>
-              </tr>
+            <tr>
+              <td>2077-06-30T18:00:00</td>
+              <td>2077-06-30T18:00:00</td>
+              <td>장기하,아이유,에픽하이,장기하,아이유,에픽하이</td>
+            </tr>
+            <tr>
+              <td>2077-06-30T18:00:00</td>
+              <td>2077-06-30T18:00:00</td>
+              <td>장기하,아이유,에픽하이</td>
+            </tr>
             </tbody>
           </v-table>
         </v-col>

--- a/src/views/admin/festival/AdminFestivalManageDetailView.vue
+++ b/src/views/admin/festival/AdminFestivalManageDetailView.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import RouterPath from '@/router/RouterPath.ts';
+</script>
+
+<template>
+  <v-container
+    class="pa-10 ma-10 pt-0"
+  >
+    <h1 class="my-2">
+      축제 상세 페이지
+    </h1>
+
+    <div>
+      <h3 class="my-2 pt-5">
+        축제 정보
+      </h3>
+      <v-row>
+        <v-col :cols="6">
+          <v-card>
+            <v-card-item
+              class="px-8 py-2"
+            >
+              <div class="py-2">
+                <v-text-field
+                  variant="outlined"
+                  label="ID"
+                  :readonly="true"
+                />
+                <v-text-field
+                  variant="outlined"
+                  label="이름"
+                  :readonly="true"
+                />
+                <v-text-field
+                  variant="outlined"
+                  label="학교 이름"
+                  :readonly="true"
+                />
+                <v-text-field
+                  variant="outlined"
+                  label="축제 시작일"
+                  :readonly="true"
+                />
+                <v-text-field
+                  variant="outlined"
+                  label="축제 종료일"
+                  :readonly="true"
+                />
+                <v-text-field
+                  variant="outlined"
+                  label="축제 포스터 URL"
+                  :readonly="true"
+                />
+                <v-text-field
+                  variant="outlined"
+                  label="생성일자"
+                  :readonly="true"
+                />
+                <v-text-field
+                  variant="outlined"
+                  label="수정일자"
+                  :readonly="true"
+                />
+              </div>
+            </v-card-item>
+          </v-card>
+        </v-col>
+      </v-row>
+    </div>
+
+    <div>
+      <h3 class="my-2 pt-5">
+        축제 관리
+      </h3>
+      <v-row>
+        <v-col :cols="3">
+          <v-card
+            class="py-2"
+            variant="outlined"
+            @click="$router.push(RouterPath.Admin.AdminFestivalManageEditPage)"
+          >
+            <v-card-item>
+              <span class="mdi mdi-pencil-outline" />
+              축제 수정/삭제
+            </v-card-item>
+          </v-card>
+        </v-col>
+      </v-row>
+    </div>
+
+    <div>
+      <h3 class="my-2 pt-5">
+        공연 관리
+      </h3>
+      <v-row>
+        <v-col :cols="3">
+          <v-card
+            class="py-2"
+            variant="outlined"
+          >
+            <v-card-item>
+              <span class="mdi mdi-plus-box-multiple-outline" />
+              공연 추가
+            </v-card-item>
+          </v-card>
+        </v-col>
+        <v-col :cols="3">
+          <v-card
+            class="py-2"
+            variant="outlined"
+          >
+            <v-card-item>
+              <span class="mdi mdi-pencil-outline" />
+              공연 수정/삭제
+            </v-card-item>
+          </v-card>
+        </v-col>
+      </v-row>
+    </div>
+  </v-container>
+</template>

--- a/src/views/admin/festival/AdminFestivalManageListView.vue
+++ b/src/views/admin/festival/AdminFestivalManageListView.vue
@@ -16,7 +16,7 @@ const tableHeaders = [
   { title: '시작일', key: 'startDate' },
   { title: '종료일', key: 'endDate' },
   { title: '공연 수', key: 'stageCount', sortable: false },
-  { title: '수정/삭제', key: 'actions', sortable: false },
+  { title: '상세', key: 'actions', sortable: false },
 ];
 const searchFilters = [
   { title: 'ID', value: 'id' },
@@ -71,7 +71,7 @@ function fetch(paging: PagingRequest) {
       :fetch="fetch"
       :item-length="items.totalElements"
       :items="items.content"
-      :detail-page-router-name="RouterPath.Admin.AdminFestivalManageEditPage.name"
+      :detail-page-router-name="RouterPath.Admin.AdminFestivalManageDetailView.name"
     />
   </v-card>
 </template>

--- a/src/views/admin/stage/AdminStageManageCreateView.vue
+++ b/src/views/admin/stage/AdminStageManageCreateView.vue
@@ -1,0 +1,188 @@
+<script setup lang="ts">
+import CreateForm from '@/components/form/CreateForm.vue';
+import { ref } from 'vue';
+import { useField, useForm } from 'vee-validate';
+import { useSnackbarStore } from '@/stores/useSnackbarStore.ts';
+import { useRoute } from 'vue-router';
+import AdminStageService from '@/api/admin/AdminStageService.ts';
+import FestagoError from '@/api/FestagoError.ts';
+import AdminArtistService from '@/api/admin/AdminArtistService.ts';
+
+type CreateStageForm = {
+  startTime: string,
+  ticketOpenTime: string
+}
+const route = useRoute();
+const snackbarStore = useSnackbarStore();
+const { handleSubmit, handleReset } = useForm<CreateStageForm>({
+  validationSchema: {
+    startTime(value: string) {
+      if (!value) return '공연 시작 시간은 필수입니다.';
+      return true;
+    },
+    ticketOpenTime(value: string) {
+      if (!value) return '티켓 오픈 시간은 필수입니다.';
+      return true;
+    },
+  },
+});
+const startTimeField = useField('startTime');
+const ticketOpenTimeField = useField('ticketOpenTime');
+
+const loading = ref(false);
+const fetchedArtists = ref<{ id: number, name: string }[]>([]);
+const artists = ref(new Map<number, { id: number, name: string }>());
+const showArtistSelectDialog = ref(false);
+const fetchArtistsLoading = ref(false);
+const artistSearchKeyword = ref('');
+
+function fetchArtists() {
+  AdminArtistService.fetchArtists().then(response => {
+    fetchedArtists.value = response.data.map(it => (
+     { id: it.id, name: it.name }
+    ));
+  });
+}
+
+function putArtist(artist: { id: number, name: string }) {
+  if (artists.value.has(artist.id)) {
+    snackbarStore.showError('이미 등록된 아티스트 입니다.');
+  } else {
+    artists.value.set(artist.id, artist);
+  }
+}
+
+function removeArtist(artist: { id: number, name: string }) {
+  artists.value.delete(artist.id);
+}
+
+const onSubmit = handleSubmit(form => {
+  loading.value = true;
+  setTimeout(() => (loading.value = false), 1000);
+  AdminStageService.createStage({
+    festivalId: parseInt(route.params.id[0]),
+    startTime: form.startTime,
+    ticketOpenTime: form.ticketOpenTime,
+    artistIds: [...artists.value.keys()],
+  }).then(() => {
+    handleReset();
+    loading.value = false;
+    snackbarStore.showSuccess('공연이 생성되었습니다!');
+  }).catch(e => {
+    if (e instanceof FestagoError) {
+      snackbarStore.showError(e.message);
+    } else throw e;
+  });
+});
+</script>
+
+<template>
+  <v-dialog
+    v-model="showArtistSelectDialog"
+    max-width="500"
+  >
+    <v-card class="pa-5">
+      <v-card-title class="text-h5 text-center">
+        아티스트 선택
+      </v-card-title>
+      <v-row :no-gutters="true" align="center">
+        <v-col :cols="10">
+          <v-text-field
+            class="pa-2 ma-2"
+            v-model="artistSearchKeyword"
+            label="아티스트 이름"
+            prepend-inner-icon="mdi-magnify"
+            :single-line="true"
+            variant="outlined"
+            :hide-details="true"
+            maxLength="50"
+          />
+        </v-col>
+        <v-col :cols="2">
+          <v-btn
+            :loading="fetchArtistsLoading"
+            :disabled="!(!!(artistSearchKeyword))"
+            class="py-7 text-h6"
+            color="blue"
+            variant="flat"
+            :block="true"
+            text="검색"
+            @click="fetchArtists"
+          />
+        </v-col>
+      </v-row>
+
+      <v-table class="text-center">
+        <thead>
+        <tr>
+          <th id="name" class="text-center">
+            이름
+          </th>
+          <th id="selectBtn" class="text-center" />
+        </tr>
+        </thead>
+        <tbody>
+        <tr
+          v-for="artist in fetchedArtists"
+          :key="artist.id"
+        >
+          <td>{{ artist.name }}</td>
+          <td>
+            <v-btn
+              @click="putArtist(artist)"
+              text="선택"
+            />
+          </td>
+        </tr>
+        </tbody>
+      </v-table>
+    </v-card>
+  </v-dialog>
+
+  <CreateForm
+    :on-submit="onSubmit"
+    :loading="loading"
+    form-title="공연 추가"
+  >
+    <div>
+      <p class="ml-2 ma-1 text-subtitle-2 text-grey-darken-2">아티스트 목록</p>
+      <v-card
+        class="pa-6 mb-6"
+        variant="outlined"
+        @click="showArtistSelectDialog = true"
+      >
+        <v-row>
+          <v-col
+            v-for="(artist, _) in artists.values()"
+            :key="artist.id"
+            class="py-1 pe-0"
+            cols="auto"
+          >
+            <v-chip
+              :closable="true"
+              @click:close="() => removeArtist(artist)"
+            >
+              {{ artist.name }}
+            </v-chip>
+          </v-col>
+        </v-row>
+      </v-card>
+    </div>
+    <v-text-field
+      class="mb-3"
+      type="datetime-local"
+      v-model="startTimeField.value.value"
+      :error-messages="startTimeField.errorMessage.value"
+      variant="outlined"
+      label="공연 시작 시간"
+    />
+    <v-text-field
+      class="mb-3"
+      type="datetime-local"
+      v-model="ticketOpenTimeField.value.value"
+      :error-messages="ticketOpenTimeField.errorMessage.value"
+      variant="outlined"
+      label="티켓 오픈 시간"
+    />
+  </CreateForm>
+</template>

--- a/src/views/admin/stage/AdminStageManageCreateView.vue
+++ b/src/views/admin/stage/AdminStageManageCreateView.vue
@@ -159,7 +159,7 @@ const onSubmit = handleSubmit(form => {
       >
         <v-row>
           <v-col
-            v-for="(artist, _) in artists.values()"
+            v-for="artist in artists.values()"
             :key="artist.id"
             class="py-1 pe-0"
             cols="auto"

--- a/src/views/admin/stage/AdminStageManageCreateView.vue
+++ b/src/views/admin/stage/AdminStageManageCreateView.vue
@@ -12,6 +12,12 @@ type CreateStageForm = {
   startTime: string,
   ticketOpenTime: string
 }
+
+type Artist = {
+  id: number,
+  name: string
+}
+
 const route = useRoute();
 const snackbarStore = useSnackbarStore();
 const { handleSubmit, handleReset } = useForm<CreateStageForm>({
@@ -30,21 +36,21 @@ const startTimeField = useField('startTime');
 const ticketOpenTimeField = useField('ticketOpenTime');
 
 const loading = ref(false);
-const fetchedArtists = ref<{ id: number, name: string }[]>([]);
-const artists = ref(new Map<number, { id: number, name: string }>());
+const fetchedArtists = ref<Artist[]>([]);
+const artists = ref(new Map<number, Artist>());
 const showArtistSelectDialog = ref(false);
 const fetchArtistsLoading = ref(false);
 const artistSearchKeyword = ref('');
 
 function fetchArtists() {
   AdminArtistService.fetchArtists().then(response => {
-    fetchedArtists.value = response.data.map(it => (
-     { id: it.id, name: it.name }
+    fetchedArtists.value = response.data.map(artist => (
+      { id: artist.id, name: artist.name }
     ));
   });
 }
 
-function putArtist(artist: { id: number, name: string }) {
+function putArtist(artist: Artist) {
   if (artists.value.has(artist.id)) {
     snackbarStore.showError('이미 등록된 아티스트 입니다.');
   } else {
@@ -52,7 +58,7 @@ function putArtist(artist: { id: number, name: string }) {
   }
 }
 
-function removeArtist(artist: { id: number, name: string }) {
+function removeArtist(artist: Artist) {
   artists.value.delete(artist.id);
 }
 


### PR DESCRIPTION
## DONE

### 축제 상세 페이지

![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/6aa29ce0-ddfa-4e26-89d2-d78e5f33e0f7)
![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/9eb3f5d5-4a74-4dda-a4b6-7e2913b8e1b1)

### 공연 추가 페이지

![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/cca4bcdd-0ebd-4e32-867c-b6864c2ab643)
![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/6e38fb5c-9f9d-46dd-b7ad-fe684e2796c8)

## TODO

- 백엔드 축제 상세 조회 API 추가되면 상세 페이지에 API 사용하도록 변경
- 백엔드 공연 목록 조회 API 추가하여 상세 페이지에 API 사용하도록 변경
- 공연 수정/삭제 기능 추가
- 아티스트 선택 시 검색 기능 작동하도록 백엔드 API 추가 및 반영