### PR TITLE
feat: 축제 상세 조회 기능 축제 상세 조회 API 사용하도록 변경 (#89)

### DIFF
--- a/src/api/spec/festival/FetchOneFestivalApiSpec.ts
+++ b/src/api/spec/festival/FetchOneFestivalApiSpec.ts
@@ -7,34 +7,17 @@ export type FetchOneFestivalRequest = {
 export type FetchOneFestivalResponse = {
   id: number,
   name: string,
-  school: {
-    name: string,
-    id: number
-  }
+  schoolId: number,
+  schoolName: string,
   startDate: string,
   endDate: string,
   posterImageUrl: string,
-  socialMedias: {
-    type: string,
-    name: string,
-    logoUrl: string,
-    url: string
-  }[],
-  stages: {
-    id: number,
-    startDateTime: string,
-    artists: {
-      id: number,
-      name: string,
-      profileImage: string,
-      backgroundImageUrl: string
-    }[]
-  }[]
+  createdAt: string,
+  updatedAt: string
 }
 
-// TODO 새로운 축제 상세 조회용 어드민 API가 필요함
 const FetchOneFestivalApiSpec = (festivalId: number): ApiSpec => ({
-  url: `/api/v1/festivals/${festivalId}`,
+  url: `/admin/api/v1/festivals/${festivalId}`,
   method: 'GET',
 });
 

--- a/src/utils/DateFormatUtil.ts
+++ b/src/utils/DateFormatUtil.ts
@@ -1,0 +1,6 @@
+export const stringToDateString = (dateString: string | null | undefined): string => {
+  if (!dateString) {
+    return '';
+  }
+  return new Date(dateString).toLocaleString()
+}

--- a/src/views/admin/festival/AdminFestivalManageDetailView.vue
+++ b/src/views/admin/festival/AdminFestivalManageDetailView.vue
@@ -1,5 +1,32 @@
 <script setup lang="ts">
 import RouterPath from '@/router/RouterPath.ts';
+import { onMounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { FetchOneFestivalResponse } from '@/api/spec/festival/FetchOneFestivalApiSpec.ts';
+import AdminFestivalService from '@/api/admin/AdminFestivalService.ts';
+import FestagoError from '@/api/FestagoError.ts';
+import { router } from '@/router';
+import { useSnackbarStore } from '@/stores/useSnackbarStore.ts';
+import { stringToDateString } from '@/utils/DateFormatUtil.ts';
+
+const route = useRoute();
+const snackbarStore = useSnackbarStore();
+
+onMounted(() => {
+  festivalId.value = parseInt(route.params.id as string);
+  AdminFestivalService.fetchOneFestival(festivalId.value).then(response => {
+    festival.value = response.data;
+  }).catch(e => {
+    if (e instanceof FestagoError) {
+      router.push(RouterPath.Admin.AdminFestivalManageListPage.path);
+      snackbarStore.showError('해당 축제를 찾을 수 없습니다.');
+    } else throw e;
+  });
+});
+
+const festivalId = ref<number>();
+const festival = ref<FetchOneFestivalResponse>();
+
 </script>
 
 <template>
@@ -25,41 +52,49 @@ import RouterPath from '@/router/RouterPath.ts';
                   variant="outlined"
                   label="ID"
                   :readonly="true"
+                  :model-value="festival?.id"
                 />
                 <v-text-field
                   variant="outlined"
                   label="이름"
                   :readonly="true"
+                  :model-value="festival?.name"
                 />
                 <v-text-field
                   variant="outlined"
                   label="학교 이름"
                   :readonly="true"
+                  :model-value="festival?.schoolName"
                 />
                 <v-text-field
                   variant="outlined"
                   label="축제 시작일"
                   :readonly="true"
+                  :model-value="festival?.startDate"
                 />
                 <v-text-field
                   variant="outlined"
                   label="축제 종료일"
                   :readonly="true"
+                  :model-value="festival?.endDate"
                 />
                 <v-text-field
                   variant="outlined"
                   label="축제 포스터 URL"
                   :readonly="true"
+                  :model-value="festival?.posterImageUrl"
                 />
                 <v-text-field
                   variant="outlined"
                   label="생성일자"
                   :readonly="true"
+                  :model-value="stringToDateString(festival?.createdAt)"
                 />
                 <v-text-field
                   variant="outlined"
                   label="수정일자"
                   :readonly="true"
+                  :model-value="stringToDateString(festival?.updatedAt)"
                 />
               </div>
             </v-card-item>

--- a/src/views/admin/festival/AdminFestivalManageEditView.vue
+++ b/src/views/admin/festival/AdminFestivalManageEditView.vue
@@ -18,7 +18,7 @@ onMounted(() => {
   festivalId.value = parseInt(route.params.id as string);
   AdminFestivalService.fetchOneFestival(festivalId.value).then(response => {
     const result = response.data;
-    schoolName.value = result.school.name;
+    schoolName.value = result.schoolName;
     resetForm({ values: result });
   }).catch(e => {
     if (e instanceof FestagoError) {


### PR DESCRIPTION
## DONE

![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/742ffb97-090f-4b2c-8cea-2817ef1b42fc)
