### PR TITLE
feat: 학교에 소셜미디어 추가하는 페이지 추가 및 소셜미디어 수정,삭제 페이지 추가 (#106)

### DIFF
--- a/src/api/admin/AdminSocialMediaService.ts
+++ b/src/api/admin/AdminSocialMediaService.ts
@@ -1,0 +1,39 @@
+import ApiService from '@/api';
+import FetchSocialMediasApiSpec, {
+  FetchSocialMediasResponse,
+} from '@/api/spec/socialmedia/FetchSocialMediasApiSpec.ts';
+import { OwnerType } from '@/type/socialmedia/OwnerType.ts';
+import CreateSocialMediaApiSpec, {
+  CreateSocialMediaRequest,
+  CreateSocialMediaResponse,
+} from '@/api/spec/socialmedia/CreateSocialMediaApiSpec.ts';
+import UpdateSocialMediaApiSpec, {
+  UpdateSocialMediaRequest,
+  UpdateSocialMediaResponse,
+} from '@/api/spec/socialmedia/UpdateSocialMediaApiSpec.ts';
+import DeleteSocialMediaApiSpec, {
+  DeleteSocialMediaResponse,
+} from '@/api/spec/socialmedia/DeleteSocialMediaApiSpec.ts';
+import FetchOneSocialMediaApiSpec, {
+  FetchOneSocialMediaResponse,
+} from '@/api/spec/socialmedia/FetchOneSocialMediaApiSpec.ts';
+
+const AdminSocialMediaService = {
+  fetchOneSocialMedia(socialMediaId: number) {
+    return ApiService.request<FetchOneSocialMediaResponse>(FetchOneSocialMediaApiSpec(socialMediaId));
+  },
+  fetchSchoolSocialMedias(schoolId: number) {
+    return ApiService.request<FetchSocialMediasResponse>(FetchSocialMediasApiSpec(schoolId, OwnerType.SCHOOL));
+  },
+  createSocialMedia(request: CreateSocialMediaRequest) {
+    return ApiService.request<CreateSocialMediaResponse>(CreateSocialMediaApiSpec, request);
+  },
+  updateSocialMedia(socialMediaId: number, request: UpdateSocialMediaRequest) {
+    return ApiService.request<UpdateSocialMediaResponse>(UpdateSocialMediaApiSpec(socialMediaId), request);
+  },
+  deleteSocialMedia(socialMediaId: number) {
+    return ApiService.request<DeleteSocialMediaResponse>(DeleteSocialMediaApiSpec(socialMediaId));
+  },
+};
+
+export default AdminSocialMediaService;

--- a/src/api/spec/socialmedia/CreateSocialMediaApiSpec.ts
+++ b/src/api/spec/socialmedia/CreateSocialMediaApiSpec.ts
@@ -1,0 +1,23 @@
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+import { OwnerType } from '@/type/socialmedia/OwnerType.ts';
+import { SocialMediaType } from '@/type/socialmedia/SocialMediaType.ts';
+
+export type CreateSocialMediaRequest = {
+  ownerId: number,
+  ownerType: OwnerType,
+  socialMediaType: SocialMediaType,
+  name: string,
+  logoUrl: string,
+  url: string,
+}
+
+export type CreateSocialMediaResponse = {
+  // empty
+}
+
+const CreateSocialMediaApiSpec: ApiSpec = {
+  url: '/admin/api/v1/socialmedias',
+  method: 'POST',
+};
+
+export default CreateSocialMediaApiSpec;

--- a/src/api/spec/socialmedia/DeleteSocialMediaApiSpec.ts
+++ b/src/api/spec/socialmedia/DeleteSocialMediaApiSpec.ts
@@ -1,0 +1,16 @@
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+
+export type DeleteSocialMediaRequest = {
+  // empty
+}
+
+export type DeleteSocialMediaResponse = {
+  // empty
+}
+
+const DeleteSocialMediaApiSpec = (socialMediaId: number): ApiSpec => ({
+  url: `/admin/api/v1/socialmedias/${socialMediaId}`,
+  method: 'DELETE',
+});
+
+export default DeleteSocialMediaApiSpec;

--- a/src/api/spec/socialmedia/FetchOneSocialMediaApiSpec.ts
+++ b/src/api/spec/socialmedia/FetchOneSocialMediaApiSpec.ts
@@ -1,0 +1,24 @@
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+import { SocialMediaType } from '@/type/socialmedia/SocialMediaType.ts';
+import { OwnerType } from '@/type/socialmedia/OwnerType.ts';
+
+export type FetchOneSocialMediaRequest = {
+  // empty
+}
+
+export type FetchOneSocialMediaResponse = {
+  id: number,
+  ownerId: number,
+  ownerType: OwnerType,
+  socialMediaType: SocialMediaType,
+  name: string,
+  logoUrl: string,
+  url: string,
+}
+
+const FetchOneSocialMediaApiSpec = (socialMediaId: number): ApiSpec => ({
+  url: `/admin/api/v1/socialmedias/${socialMediaId}`,
+  method: 'GET',
+});
+
+export default FetchOneSocialMediaApiSpec;

--- a/src/api/spec/socialmedia/FetchSocialMediasApiSpec.ts
+++ b/src/api/spec/socialmedia/FetchSocialMediasApiSpec.ts
@@ -1,0 +1,16 @@
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+import { FetchOneSocialMediaResponse } from '@/api/spec/socialmedia/FetchOneSocialMediaApiSpec.ts';
+import { OwnerType } from '@/type/socialmedia/OwnerType.ts';
+
+export type FetchSocialMediasRequest = {
+  // empty
+}
+
+export type FetchSocialMediasResponse = FetchOneSocialMediaResponse[]
+
+const FetchSocialMediasApiSpec = (ownerId: number, ownerType: OwnerType): ApiSpec => ({
+  url: `/admin/api/v1/socialmedias?ownerId=${ownerId}&ownerType=${ownerType}`,
+  method: 'GET',
+});
+
+export default FetchSocialMediasApiSpec;

--- a/src/api/spec/socialmedia/UpdateSocialMediaApiSpec.ts
+++ b/src/api/spec/socialmedia/UpdateSocialMediaApiSpec.ts
@@ -1,0 +1,18 @@
+import ApiSpec from '@/api/spec/ApiSpec.ts';
+
+export type UpdateSocialMediaRequest = {
+  name: string,
+  logoUrl: string,
+  url: string,
+}
+
+export type UpdateSocialMediaResponse = {
+  // empty
+}
+
+const UpdateSocialMediaApiSpec = (socialMediaId: number): ApiSpec => ({
+  url: `/admin/api/v1/socialmedias/${socialMediaId}`,
+  method: 'PATCH',
+});
+
+export default UpdateSocialMediaApiSpec;

--- a/src/router/RouterPath.ts
+++ b/src/router/RouterPath.ts
@@ -16,6 +16,10 @@ import AdminFestivalManageEditView from '@/views/admin/festival/AdminFestivalMan
 import AdminFestivalManageDetailView from '@/views/admin/festival/AdminFestivalManageDetailView.vue';
 import AdminStageManageCreateView from '@/views/admin/stage/AdminStageManageCreateView.vue';
 import AdminAccountCreateView from '@/views/admin/root/AdminAccountCreateView.vue';
+import AdminSchoolManageDetailView from '@/views/admin/school/AdminSchoolManageDetailView.vue';
+import AdminSchoolSocialMediaManageCreateView
+  from '@/views/admin/school/socialmedia/AdminSchoolSocialMediaManageCreateView.vue';
+import AdminSocialMediaManageEditView from '@/views/admin/socialmedia/AdminSocialMediaManageEditView.vue';
 
 const RouterPath = {
   Common: {
@@ -53,6 +57,11 @@ const RouterPath = {
       name: 'adminMyPage',
       component: AdminMyPageView,
     },
+    AdminSchoolManageDetailView: {
+      path: '/admin/schools/:id',
+      name: 'AdminSchoolManageDetailPage',
+      component: AdminSchoolManageDetailView,
+    },
     AdminSchoolManageListPage: {
       path: '/admin/schools',
       name: 'adminSchoolManageListPage',
@@ -67,6 +76,11 @@ const RouterPath = {
       path: '/admin/schools/:id/edit',
       name: 'adminSchoolManageEditPage',
       component: AdminSchoolManageEditView,
+    },
+    AdminSchoolSocialMediaManageCreateView: {
+      path: '/admin/schools/:id/socialmedia/create',
+      name: 'AdminSchoolSocialMediaManageCreatePage',
+      component: AdminSchoolSocialMediaManageCreateView,
     },
     AdminArtistManageCreatePage: {
       path: '/admin/artist/create', // 명시적으로 단수형 사용
@@ -107,6 +121,11 @@ const RouterPath = {
       path: '/admin/festivals/:id/stage/create',
       name: 'adminStageManageCreatePage',
       component: AdminStageManageCreateView,
+    },
+    AdminSocialMediaManageEditView: {
+      path: '/admin/socialmedias/:id/edit',
+      name: 'AdminSocialMediaManageEditPage',
+      component: AdminSocialMediaManageEditView,
     },
   },
   School: {

--- a/src/type/socialmedia/OwnerType.ts
+++ b/src/type/socialmedia/OwnerType.ts
@@ -1,0 +1,5 @@
+export const OwnerType = {
+  ARTIST: 'ARTIST',
+  SCHOOL: 'SCHOOL',
+} as const;
+export type OwnerType = typeof OwnerType[keyof typeof OwnerType]

--- a/src/type/socialmedia/SocialMediaType.ts
+++ b/src/type/socialmedia/SocialMediaType.ts
@@ -1,0 +1,7 @@
+export const SocialMediaType = {
+  YOUTUBE: 'YOUTUBE',
+  X: 'X',
+  INSTAGRAM: 'INSTAGRAM',
+  FACEBOOK: 'FACEBOOK',
+} as const;
+export type SocialMediaType = typeof SocialMediaType[keyof typeof SocialMediaType]

--- a/src/views/admin/school/AdminSchoolManageDetailView.vue
+++ b/src/views/admin/school/AdminSchoolManageDetailView.vue
@@ -1,0 +1,183 @@
+<script setup lang="ts">
+
+import { useRoute } from 'vue-router';
+import { useSnackbarStore } from '@/stores/useSnackbarStore.ts';
+import { onMounted, Ref, ref } from 'vue';
+import FestagoError from '@/api/FestagoError.ts';
+import { router } from '@/router';
+import RouterPath from '@/router/RouterPath.ts';
+import { FetchOneSchoolResponse } from '@/api/spec/school/FetchOneSchoolApiSpec.ts';
+import AdminSchoolService from '@/api/admin/AdminSchoolService.ts';
+import { FetchSocialMediasResponse } from '@/api/spec/socialmedia/FetchSocialMediasApiSpec.ts';
+import AdminSocialMediaService from '@/api/admin/AdminSocialMediaService.ts';
+
+const route = useRoute();
+const snackbarStore = useSnackbarStore();
+const schoolId = ref<number>();
+const school = ref<FetchOneSchoolResponse>();
+const socialMedias: Ref<FetchSocialMediasResponse> = ref([]);
+
+onMounted(() => {
+  schoolId.value = parseInt(route.params.id as string);
+  AdminSchoolService.fetchOneSchool(schoolId.value).then(response => {
+    school.value = response.data;
+  }).catch(e => {
+    if (e instanceof FestagoError) {
+      router.push(RouterPath.Admin.AdminFestivalManageListPage.path);
+      snackbarStore.showError('해당 학교를 찾을 수 없습니다.');
+    } else throw e;
+  });
+  AdminSocialMediaService.fetchSchoolSocialMedias(schoolId.value).then(response => {
+    socialMedias.value = response.data;
+  });
+});
+
+</script>
+
+<template>
+  <v-container
+    class="pa-10 ma-10 pt-0"
+  >
+    <h1 class="my-2">
+      학교 상세 페이지
+    </h1>
+
+    <div>
+      <v-row>
+        <v-col :cols="5">
+          <h3 class="my-2 pt-5">
+            학교 정보
+          </h3>
+          <v-card>
+            <v-card-item
+              class="px-8 py-2"
+            >
+              <div class="py-2">
+                <v-text-field
+                  variant="outlined"
+                  label="ID"
+                  :readonly="true"
+                  :model-value="school?.id"
+                />
+                <v-text-field
+                  variant="outlined"
+                  label="이름"
+                  :readonly="true"
+                  :model-value="school?.name"
+                />
+                <v-text-field
+                  variant="outlined"
+                  label="도메인"
+                  :readonly="true"
+                  :model-value="school?.domain"
+                />
+                <v-text-field
+                  variant="outlined"
+                  label="지역"
+                  :readonly="true"
+                  :model-value="school?.region"
+                />
+                <v-text-field
+                  variant="outlined"
+                  label="로고 URL"
+                  :readonly="true"
+                  :model-value="school?.logoUrl"
+                />
+                <v-text-field
+                  variant="outlined"
+                  label="백그라운드 이미지 URL"
+                  :readonly="true"
+                  :model-value="school?.backgroundImageUrl"
+                />
+              </div>
+            </v-card-item>
+          </v-card>
+        </v-col>
+        <v-col :cols="7">
+          <h3 class="my-2 pt-5">
+            소셜미디어 목록
+          </h3>
+          <v-table>
+            <thead>
+            <tr>
+              <th id="id">
+                ID
+              </th>
+              <th id="socialMediaType">
+                소셜미디어 타입
+              </th>
+              <th id="name">
+                이름
+              </th>
+              <th id="edit">
+                수정/삭제
+              </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr
+              v-for="socialMedia in socialMedias"
+              :key="socialMedia.id"
+            >
+              <td>{{ socialMedia.id }}</td>
+              <td>{{ socialMedia.socialMediaType }}</td>
+              <td>{{ socialMedia.name }}</td>
+              <td>
+                <v-icon
+                  class="mr-2"
+                  icon="mdi-pencil"
+                  color="grey-darken-3"
+                  @click="$router.push({
+                    name: RouterPath.Admin.AdminSocialMediaManageEditView.name,
+                    params: { id: socialMedia.id }
+                  })"
+                />
+              </td>
+            </tr>
+            </tbody>
+          </v-table>
+        </v-col>
+      </v-row>
+    </div>
+
+    <div>
+      <h3 class="my-2 pt-5">
+        학교 관리
+      </h3>
+      <v-row>
+        <v-col :cols="3">
+          <v-card
+            class="py-2"
+            variant="outlined"
+            @click="$router.push(RouterPath.Admin.AdminSchoolManageEditPage)"
+          >
+            <v-card-item>
+              <span class="mdi mdi-pencil-outline" />
+              학교 수정/삭제
+            </v-card-item>
+          </v-card>
+        </v-col>
+      </v-row>
+    </div>
+
+    <div>
+      <h3 class="my-2 pt-5">
+        소셜미디어 관리
+      </h3>
+      <v-row>
+        <v-col :cols="3">
+          <v-card
+            class="py-2"
+            variant="outlined"
+            @click="$router.push(RouterPath.Admin.AdminSchoolSocialMediaManageCreateView)"
+          >
+            <v-card-item>
+              <span class="mdi mdi-plus-box-multiple-outline" />
+              소셜미디어 추가
+            </v-card-item>
+          </v-card>
+        </v-col>
+      </v-row>
+    </div>
+  </v-container>
+</template>

--- a/src/views/admin/school/AdminSchoolManageListView.vue
+++ b/src/views/admin/school/AdminSchoolManageListView.vue
@@ -13,7 +13,7 @@ const tableHeaders = [
   { title: '이름', key: 'name' },
   { title: '도메인', key: 'domain' },
   { title: '지역', key: 'region' },
-  { title: '수정/삭제', key: 'actions', sortable: false },
+  { title: '상세', key: 'actions', sortable: false },
 ];
 const searchFilters = [
   { title: 'ID', value: 'id' },
@@ -67,7 +67,7 @@ function fetch(paging: PagingRequest) {
       :fetch="fetch"
       :item-length="items.totalElements"
       :items="items.content"
-      :detail-page-router-name="RouterPath.Admin.AdminSchoolManageEditPage.name"
+      :detail-page-router-name="RouterPath.Admin.AdminSchoolManageDetailView.name"
     />
   </v-card>
 </template>

--- a/src/views/admin/school/socialmedia/AdminSchoolSocialMediaManageCreateView.vue
+++ b/src/views/admin/school/socialmedia/AdminSchoolSocialMediaManageCreateView.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+
+import { useSnackbarStore } from '@/stores/useSnackbarStore.ts';
+import { useField, useForm } from 'vee-validate';
+import { OwnerType } from '@/type/socialmedia/OwnerType.ts';
+import { SocialMediaType } from '@/type/socialmedia/SocialMediaType.ts';
+import FestagoError from '@/api/FestagoError.ts';
+import { useRoute } from 'vue-router';
+import AdminSocialMediaService from '@/api/admin/AdminSocialMediaService.ts';
+import CreateForm from '@/components/form/CreateForm.vue';
+
+type CreateSchoolSocialMediaForm = {
+  socialMediaType: SocialMediaType,
+  name: string,
+  logoUrl: string,
+  url: string,
+}
+
+const route = useRoute();
+const snackbarStore = useSnackbarStore();
+const { isSubmitting, handleSubmit, setErrors, handleReset } = useForm<CreateSchoolSocialMediaForm>({
+  validationSchema: {
+    socialMediaType(value: string) {
+      if (!value) return '소셜미디어 타입은 필수입니다.';
+      return true;
+    },
+    name(value: string) {
+      if (!value) return '소셜미디어 이름은 필수입니다.';
+      return true;
+    },
+    logoUrl(value: string) {
+      if (!value) return '로고 URL은 필수입니다.';
+      if (value.length >= 255) return '로고 URL은 255글자 미만이어야 합니다.';
+      if (!value.startsWith('https://')) return '로고 URL은 https://로 시작되어야 합니다.';
+      if (!/\.(png|jpg)$/.test(value)) return '로고 URL은 png,jpg와 같은 이미지 파일으로 끝나야 합니다.';
+      return true;
+    },
+    url(value: string) {
+      if (!value) return 'URL은 필수입니다.';
+      if (value.length >= 255) return 'URL은 255글자 미만이어야 합니다.';
+      if (!value.startsWith('https://')) return 'URL은 https://로 시작되어야 합니다.';
+      return true;
+    },
+  },
+});
+
+const socialMediaTypeField = useField<string>('socialMediaType');
+const nameField = useField<string>('name');
+const logoUrlField = useField<string>('logoUrl');
+const urlField = useField<string>('url');
+
+const onSubmit = handleSubmit(async form => {
+  try {
+    await AdminSocialMediaService.createSocialMedia({
+      ownerId: parseInt(route.params.id[0]),
+      ownerType: OwnerType.SCHOOL,
+      socialMediaType: form.socialMediaType,
+      name: form.name,
+      logoUrl: form.logoUrl,
+      url: form.url,
+    });
+    handleReset();
+    snackbarStore.showSuccess('소셜미디어가 생성되었습니다!');
+  } catch (e) {
+    if (e instanceof FestagoError) {
+      if (e.isValidError()) {
+        setErrors(e.result);
+      } else {
+        snackbarStore.showError(e.message);
+      }
+    } else throw e;
+  }
+});
+
+</script>
+
+<template>
+  <CreateForm
+    :on-submit="onSubmit"
+    :loading="isSubmitting"
+    form-title="학교 소셜미디어 추가"
+  >
+    <v-select
+      class="mb-3"
+      :items="Object.values(SocialMediaType)"
+      v-model="socialMediaTypeField.value.value"
+      :error-messages="socialMediaTypeField.errorMessage.value"
+      variant="outlined"
+      label="소셜 미디어 타입"
+    />
+    <v-text-field
+      class="mb-3"
+      type="text"
+      v-model="nameField.value.value"
+      :error-messages="nameField.errorMessage.value"
+      variant="outlined"
+      label="이름"
+    />
+    <v-text-field
+      class="mb-3"
+      type="text"
+      v-model="logoUrlField.value.value"
+      :error-messages="logoUrlField.errorMessage.value"
+      variant="outlined"
+      label="로고 URL"
+    />
+    <v-text-field
+      class="mb-3"
+      type="text"
+      v-model="urlField.value.value"
+      :error-messages="urlField.errorMessage.value"
+      variant="outlined"
+      label="URL"
+    />
+  </CreateForm>
+</template>

--- a/src/views/admin/socialmedia/AdminSocialMediaManageEditView.vue
+++ b/src/views/admin/socialmedia/AdminSocialMediaManageEditView.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+
+import { useRoute } from 'vue-router';
+import { useSnackbarStore } from '@/stores/useSnackbarStore.ts';
+import { onMounted, ref } from 'vue';
+import FestagoError from '@/api/FestagoError.ts';
+import { router } from '@/router';
+import RouterPath from '@/router/RouterPath.ts';
+import { useField, useForm } from 'vee-validate';
+import AdminSocialMediaService from '@/api/admin/AdminSocialMediaService.ts';
+import { UpdateSocialMediaRequest } from '@/api/spec/socialmedia/UpdateSocialMediaApiSpec.ts';
+import EditForm from '@/components/form/EditForm.vue';
+import { FetchOneSocialMediaResponse } from '@/api/spec/socialmedia/FetchOneSocialMediaApiSpec.ts';
+
+const route = useRoute();
+const snackbarStore = useSnackbarStore();
+
+onMounted(() => {
+  socialMediaId.value = parseInt(route.params.id as string);
+  AdminSocialMediaService.fetchOneSocialMedia(socialMediaId.value).then(response => {
+    socialMedia.value = response.data;
+    resetForm({ values: response.data });
+  }).catch(e => {
+    if (e instanceof FestagoError) {
+      router.push(RouterPath.Admin.AdminSchoolManageListPage.path);
+      snackbarStore.showError('해당 소셜미디어를 찾을 수 없습니다.');
+    } else throw e;
+  });
+});
+
+const { isSubmitting, meta, resetForm, setErrors, handleSubmit } = useForm<UpdateSocialMediaRequest>({
+  validationSchema: {
+    name(value: string) {
+      if (!value) return '소셜미디어 이름은 필수입니다.';
+      return true;
+    },
+    logoUrl(value: string) {
+      if (!value) return '로고 URL은 필수입니다.';
+      if (value.length >= 255) return '로고 URL은 255글자 미만이어야 합니다.';
+      if (!value.startsWith('https://')) return '로고 URL은 https://로 시작되어야 합니다.';
+      if (!/\.(png|jpg)$/.test(value)) return '로고 URL은 png,jpg와 같은 이미지 파일으로 끝나야 합니다.';
+      return true;
+    },
+    url(value: string) {
+      if (!value) return 'URL은 필수입니다.';
+      if (value.length >= 255) return 'URL은 255글자 미만이어야 합니다.';
+      if (!value.startsWith('https://')) return 'URL은 https://로 시작되어야 합니다.';
+      return true;
+    },
+  },
+});
+
+const socialMediaId = ref<number>();
+const socialMedia = ref<FetchOneSocialMediaResponse>();
+const nameField = useField<string>('name');
+const logoUrlField = useField<string>('logoUrl');
+const urlField = useField<string>('url');
+
+const onUpdateSubmit = handleSubmit(async request => {
+  try {
+    await AdminSocialMediaService.updateSocialMedia(socialMediaId.value!, request);
+    snackbarStore.showSuccess('소셜미디어가 수정되었습니다.');
+    resetForm({ values: request });
+  } catch (e) {
+    if (e instanceof FestagoError) {
+      if (e.isValidError()) {
+        setErrors(e.result);
+      } else {
+        snackbarStore.showError(e.message);
+      }
+    } else throw e;
+  }
+});
+
+function onDeleteSubmit() {
+  AdminSocialMediaService.deleteSocialMedia(socialMediaId.value!).then(() => {
+    snackbarStore.showSuccess('소셜미디어가 삭제되었습니다.');
+    router.back();
+  }).catch(e => {
+    if (e instanceof FestagoError) {
+      snackbarStore.showError(e.message);
+    } else throw e;
+  });
+}
+
+</script>
+
+<template>
+  <EditForm
+    form-title="소셜미디어 수정/삭제"
+    :loading="isSubmitting"
+    :on-update-submit="onUpdateSubmit"
+    :on-delete-submit="onDeleteSubmit"
+    :is-touched="meta.dirty"
+  >
+    <v-text-field
+      class="mb-3"
+      variant="outlined"
+      label="ID"
+      :model-value="socialMediaId"
+      :readonly="true"
+    />
+    <v-text-field
+      class="mb-3"
+      variant="outlined"
+      label="Owner ID"
+      :model-value="socialMedia?.ownerId"
+      :readonly="true"
+    />
+    <v-text-field
+      class="mb-3"
+      variant="outlined"
+      label="Owner type"
+      :model-value="socialMedia?.ownerType"
+      :readonly="true"
+    />
+    <v-text-field
+      class="mb-3"
+      type="text"
+      v-model="nameField.value.value"
+      :error-messages="nameField.errorMessage.value"
+      variant="outlined"
+      label="이름"
+    />
+    <v-text-field
+      class="mb-3"
+      type="text"
+      v-model="logoUrlField.value.value"
+      :error-messages="logoUrlField.errorMessage.value"
+      variant="outlined"
+      label="로고 URL"
+    />
+    <v-text-field
+      class="mb-3"
+      type="text"
+      v-model="urlField.value.value"
+      :error-messages="urlField.errorMessage.value"
+      variant="outlined"
+      label="URL"
+    />
+  </EditForm>
+</template>


### PR DESCRIPTION
## DONE

 ![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/94c0b078-3fc0-4474-89c1-76d62cf694d5)

![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/e7a18464-5ae8-414d-bfd4-825d032473a4)

![image](https://github.com/seokjin8678/festago-manager-front/assets/116627736/e4b093ee-b4a3-4578-bc19-17eef7a9a9ff)

## TODO

- 학교 응답에 로고 URL, 백그라운드 이미지 URL가 누락되어 상세 페이지에서 보여줄 수 없음.
- 또한 createdAt, updatedAt 필드 추가 필요
- 소셜미디어의 로고 URL을 따로 저장할 필요가 있을까?
  - 백엔드에서 SocialMediaType Enum에 URL을 지정하는게 어떨까?